### PR TITLE
Add pandas python library

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.1.0
+VERSION=0.2.0
 
 # build agent
 lein uberjar


### PR DESCRIPTION
This PR adds `pandas` library and changes the base image of to debian/python3.
This was necessary because the build was taking 20~25 minutes due to:

> Most Python packages these days include binary wheels on PyPI, significantly speeding install time. But if you’re using Alpine Linux you need to compile all the C code in every Python package that you use.

Ref: https://pythonspeed.com/articles/alpine-docker-python/

The size of image increased ~40% due to numpy + pandas lib:

```
runops/agent   0.0.26    fd54b23404f6   19 minutes ago   1.43GB
runops/agent   0.0.25    6b11f9ac98c6   3 days ago       828MB
```

Python versions were pin to avoid updating it on new releases

Related: https://github.com/runopsio/tbd/pull/34