### PR TITLE
normalize empty string when parsing mapping

### DIFF
--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -231,8 +231,11 @@
 (defn- add-secrets-from-mapping [task]
   (try
     (let [secrets (:secrets task)
-          secret-mapping (keywordize-keys (json/read-str
-                                           (or (:secret-mapping task) "{}")))]
+          secret-mapping (:secret-mapping task)
+          secret-mapping (keywordize-keys
+                          (json/read-str
+                           (if (clojure.string/blank? secret-mapping)
+                             "{}" secret-mapping)))]
       [(assoc task :secrets
               (into secrets
                     (map (fn [[k v]]

--- a/test/agent/agent_test.clj
+++ b/test/agent/agent_test.clj
@@ -20,4 +20,10 @@
                 {:secrets {:PG_HOST "127.0.0.1" :PG_USER "myuser"}})]
       (is (= {:PG_HOST "127.0.0.1" :PG_USER "myuser"}
              (select-keys
-              (:secrets (first task)) [:PG_HOST :PG_USER]))))))
+              (:secrets (first task)) [:PG_HOST :PG_USER])))))
+  (testing "must continue if secret mapping has empty string"
+    (let [task (@#'a/add-secrets-from-mapping {:secrets {:PG_HOST "127.0.0.1"}
+                                               :secret-mapping ""})]
+      (is (= {:PG_HOST "127.0.0.1"}
+             (select-keys
+              (:secrets (first task)) [:PG_HOST]))))))


### PR DESCRIPTION
It was causing an error in `read-string` when the `secret-mapping` was empty