### PR TITLE
Add honeycomb tracing

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,5 @@
-{:lint-as {mount.core/defstate clojure.core/def}}
+{:lint-as {mount.core/defstate clojure.core/def
+           cambium.core/deflevel clojure.core/def}}
 {:linters
  {:unresolved-namespace {:report-duplicates true}
   :unresolved-symbol {:report-duplicates true

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject agent "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+(defproject agent "0.1.5"
+  :description "Runops Agent"
+  :url "https://github.com/runops/agent"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.3"]
@@ -17,6 +17,7 @@
 
                  ; monitoring
                  [io.sentry/sentry-logback "5.0.1"]
+                 [io.honeycomb/honeycomb-opentelemetry-sdk "0.4.0"]
 
                  ; logging
                  [cambium "0.8.1"]
@@ -30,6 +31,7 @@
                  [camel-snake-kebab "0.4.2"]
                  [de.ubercode.clostache/clostache "1.4.0"]
                  [buddy "2.0.0"]]
+  :plugins [[lein-bump-version "0.1.6"]]
   :source-paths ["src" "test"]
   :main ^:skip-aot agent.core
   :target-path "target/%s"

--- a/resources/agent.proto
+++ b/resources/agent.proto
@@ -13,6 +13,8 @@ message TaskResponse {
   string secret_path = 5;
   string secret_mapping = 6;
   string config = 7;
+  string x_b3_trace_id = 8;
+  string x_b3_parent_span_id = 9;
 }
 
 message LogsRequest {

--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -8,7 +8,9 @@
             [clj-http.client :as http-client]
             [clojure.data.json :as json]
             [clojure.walk :refer [keywordize-keys]]
-            [clostache.parser :as parser])
+            [clostache.parser :as parser]
+            [tracer.honeycomb :refer [with-tracing
+                                      with-tracing-end]])
   (:import java.io.File
            io.sentry.Sentry))
 
@@ -188,12 +190,13 @@
 
 (defn run-task [task]
   (err/err->> task
-              parse-command
-              lock-task
-              get-secrets
-              add-secrets-from-mapping
-              validate-secrets
-              render-script
+              (with-tracing parse-command [:run-agent-task])
+              (with-tracing lock-task [:run-agent-task :lock-task])
+              (with-tracing get-secrets [:run-agent-task :get-secrets])
+              (with-tracing add-secrets-from-mapping [:run-agent-task :add-secrets-from-mapping])
+              (with-tracing validate-secrets [:run-agent-task :validate-secrets])
+              (with-tracing render-script [:run-agent-task :render-script])
+              (with-tracing-end)
               run-command))
 
 (defn parse-command [task]

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -1,6 +1,6 @@
 (ns agent.core
   (:require [cambium.core :as log]
-            [agent.clients :as clients]
+            [agent.clients :as _]
             [agent.http-poller :as http]
             [agent.grpc-subscriber :as grcp]
             [mount.core :as mount])
@@ -10,10 +10,11 @@
 
 (defn -main [& args]
   (log/info (format "Starting agent tagged with [%s]" tags))
-
+  (log/info (format "version=%s, revision=%s"
+                    (System/getProperty "agent.version")
+                    (System/getProperty "agent.revision")))
   ; mount clients
   (mount/start)
-
   (grcp/listen-subscription)
   (http/poll))
 

--- a/src/io/grpc.cljc
+++ b/src/io/grpc.cljc
@@ -92,29 +92,33 @@
 ;-----------------------------------------------------------------------------
 ; TaskResponse
 ;-----------------------------------------------------------------------------
-(defrecord TaskResponse-record [id type script secret-provider secret-path secret-mapping config]
+(defrecord TaskResponse-record [config x-b3-parent-span-id id secret-provider script secret-path type secret-mapping x-b3-trace-id]
   pb/Writer
   (serialize [this os]
+    (serdes.core/write-String 7  {:optimize true} (:config this) os)
+    (serdes.core/write-String 9  {:optimize true} (:x-b3-parent-span-id this) os)
     (serdes.core/write-Int32 1  {:optimize true} (:id this) os)
-    (serdes.core/write-String 2  {:optimize true} (:type this) os)
-    (serdes.core/write-String 3  {:optimize true} (:script this) os)
     (serdes.core/write-String 4  {:optimize true} (:secret-provider this) os)
+    (serdes.core/write-String 3  {:optimize true} (:script this) os)
     (serdes.core/write-String 5  {:optimize true} (:secret-path this) os)
+    (serdes.core/write-String 2  {:optimize true} (:type this) os)
     (serdes.core/write-String 6  {:optimize true} (:secret-mapping this) os)
-    (serdes.core/write-String 7  {:optimize true} (:config this) os))
+    (serdes.core/write-String 8  {:optimize true} (:x-b3-trace-id this) os))
   pb/TypeReflection
   (gettype [this]
     "io.grpc.TaskResponse"))
 
-(s/def :io.grpc.TaskResponse/id int?)
-(s/def :io.grpc.TaskResponse/type string?)
-(s/def :io.grpc.TaskResponse/script string?)
-(s/def :io.grpc.TaskResponse/secret-provider string?)
-(s/def :io.grpc.TaskResponse/secret-path string?)
-(s/def :io.grpc.TaskResponse/secret-mapping string?)
 (s/def :io.grpc.TaskResponse/config string?)
-(s/def ::TaskResponse-spec (s/keys :opt-un [:io.grpc.TaskResponse/id :io.grpc.TaskResponse/type :io.grpc.TaskResponse/script :io.grpc.TaskResponse/secret-provider :io.grpc.TaskResponse/secret-path :io.grpc.TaskResponse/secret-mapping :io.grpc.TaskResponse/config ]))
-(def TaskResponse-defaults {:id 0 :type "" :script "" :secret-provider "" :secret-path "" :secret-mapping "" :config "" })
+(s/def :io.grpc.TaskResponse/x-b3-parent-span-id string?)
+(s/def :io.grpc.TaskResponse/id int?)
+(s/def :io.grpc.TaskResponse/secret-provider string?)
+(s/def :io.grpc.TaskResponse/script string?)
+(s/def :io.grpc.TaskResponse/secret-path string?)
+(s/def :io.grpc.TaskResponse/type string?)
+(s/def :io.grpc.TaskResponse/secret-mapping string?)
+(s/def :io.grpc.TaskResponse/x-b3-trace-id string?)
+(s/def ::TaskResponse-spec (s/keys :opt-un [:io.grpc.TaskResponse/config :io.grpc.TaskResponse/x-b3-parent-span-id :io.grpc.TaskResponse/id :io.grpc.TaskResponse/secret-provider :io.grpc.TaskResponse/script :io.grpc.TaskResponse/secret-path :io.grpc.TaskResponse/type :io.grpc.TaskResponse/secret-mapping :io.grpc.TaskResponse/x-b3-trace-id ]))
+(def TaskResponse-defaults {:config "" :x-b3-parent-span-id "" :id 0 :secret-provider "" :script "" :secret-path "" :type "" :secret-mapping "" :x-b3-trace-id "" })
 
 (defn cis->TaskResponse
   "CodedInputStream to TaskResponse"
@@ -122,13 +126,15 @@
   (->> (tag-map TaskResponse-defaults
          (fn [tag index]
              (case index
-               1 [:id (serdes.core/cis->Int32 is)]
-               2 [:type (serdes.core/cis->String is)]
-               3 [:script (serdes.core/cis->String is)]
-               4 [:secret-provider (serdes.core/cis->String is)]
-               5 [:secret-path (serdes.core/cis->String is)]
-               6 [:secret-mapping (serdes.core/cis->String is)]
                7 [:config (serdes.core/cis->String is)]
+               9 [:x-b3-parent-span-id (serdes.core/cis->String is)]
+               1 [:id (serdes.core/cis->Int32 is)]
+               4 [:secret-provider (serdes.core/cis->String is)]
+               3 [:script (serdes.core/cis->String is)]
+               5 [:secret-path (serdes.core/cis->String is)]
+               2 [:type (serdes.core/cis->String is)]
+               6 [:secret-mapping (serdes.core/cis->String is)]
+               8 [:x-b3-trace-id (serdes.core/cis->String is)]
 
                [index (serdes.core/cis->undefined tag is)]))
          is)

--- a/src/tracer/honeycomb.clj
+++ b/src/tracer/honeycomb.clj
@@ -1,0 +1,163 @@
+(ns tracer.honeycomb
+  (:require [cambium.core :as log]
+            [mount.core :refer [defstate start]]
+            [agent.errors :as err])
+  (:import io.opentelemetry.context.Context
+           io.honeycomb.opentelemetry.HoneycombSdk$Builder
+           io.honeycomb.opentelemetry.sdk.trace.samplers.DeterministicTraceSampler))
+
+(def ^:private api-key "e8f9fb62e7ff1ece4d8020df4cff5954")
+(def ^:private dataset "runops")
+(def ^:private service-name "runops-agent")
+
+(defn- build-honeycomb-sdk []
+  (try
+    (-> (new HoneycombSdk$Builder)
+        (.setApiKey api-key)
+        (.setDataset dataset)
+        (.setSampler (new DeterministicTraceSampler 1))
+        (.setServiceName service-name)
+        (.build))
+    (catch Exception e
+      (log/warn (format "failed to start honeycomb sdk with error %s" e)))))
+
+(defstate ^:private honeycomb-sdk
+  :start (build-honeycomb-sdk)
+  :stop nil)
+
+(declare trace-task
+         safe-end
+         set-span-attributes
+         tracer
+         call-traced-fn)
+
+(defn with-tracing
+  "A closure that execute functions with tracing on honeycomb.
+  It builds a graph automatically using a tuple of keywords (span-tuple),
+  example:
+  
+  (agent.errors/err->> 
+   task
+   (with-tracing bird-fn [:bird])
+   (with-tracing hawk-fn [:bird :hawk])
+   (with-tracing eagle-fn [:bird :eagle])
+   (with-tracing nest-fn [:eagle :nest])
+   (with-tracing egg-fn [:eagle :egg])
+   (with-tracing-end)))
+
+  The following graph is created on honeycomb:
+
+  |- bird
+    |- hawk
+    |- eagle
+      |-- nest
+      |-- egg"
+  [traced-fn span-tuple & map-attrs]
+  (when (not (coll? span-tuple))
+    (throw (Exception. "span-tuple must implement IPersistentCollection")))
+  (fn [task]
+    (let [root-key (first span-tuple)
+          parent-key (second span-tuple)
+          root-span (get-in task [:tracing-spans root-key])
+          map-attrs (apply merge map-attrs)]
+      (if root-span
+        (trace-task traced-fn task parent-key root-span map-attrs)
+        (trace-task traced-fn task root-key map-attrs)))))
+
+(defn with-tracing-end []
+  (fn [task]
+    (when-let [spans (:tracing-spans task)]
+      (doall (map safe-end (vals spans)))
+      [task nil])
+    [task nil]))
+
+(defn- trace-task
+  ([traced-fn task parent-key root-span map-attrs]
+   (let [parent-span (set-span-attributes
+                      (-> (tracer)
+                          (.spanBuilder (name parent-key))
+                          (.setParent (-> (Context/current)
+                                          (.with root-span)))
+                          (.startSpan))
+                      map-attrs)
+         fn-result (call-traced-fn traced-fn
+                                   (assoc task :tracing-spans
+                                          (merge (:tracing-spans task)
+                                                 {parent-key parent-span})))]
+     (set-span-attributes parent-span {:message (second fn-result)})
+     (when (some? (second fn-result))
+       ((with-tracing-end) task))
+     (safe-end parent-span)
+     fn-result))
+  ([traced-fn task root-key map-attrs]
+   (let [root-span (set-span-attributes
+                    (-> (tracer)
+                        (.spanBuilder (name root-key))
+                        (.startSpan))
+                    (merge map-attrs
+                           {:task-id (:id task)
+                            :agent-version (System/getProperty "agent.version")
+                            :agent-revision (System/getProperty "agent.revision")}))
+         fn-result (call-traced-fn traced-fn (assoc task :tracing-spans
+                                                    {root-key root-span}))]
+     (set-span-attributes root-span {:message (second fn-result)})
+     (when (some? (second fn-result))
+       ((with-tracing-end) task))
+     fn-result)))
+
+(defn- call-traced-fn [traced-fn task]
+  (try
+    (traced-fn task)
+    (catch Exception e
+      [nil (format "failed in processing, err=%s" (.getMessage e))])))
+
+(defn- safe-end [span]
+  (try (.end span) (catch Exception _))
+  span)
+
+(defn- tracer []
+  (-> honeycomb-sdk
+      (.getTracer service-name)))
+
+(defn- set-span-attribute [span key value]
+  (try
+    (.setAttribute span key (str value))
+    (catch Exception e
+      (log/warn (format "failed to set span attribute with error %s" e)))))
+
+(defn- set-span-attribute-list [span attribute-list]
+  (if (= (count attribute-list) 0)
+    span
+    (do (set-span-attribute span (first (first attribute-list)) (second (first attribute-list)))
+        (set-span-attribute-list span (rest attribute-list)))))
+
+(defn- set-span-attributes
+  "Apply all the attributes from the map to the span as string:string"
+  [span attributes-map]
+  (set-span-attribute-list span (doall (map #(vector (name (first %)) (str (second %))) attributes-map))))
+
+(comment
+  ;; running it will create a trace on honeycomb where task-id=uuid
+  (start #'honeycomb-sdk)
+  (let [id (str (java.util.UUID/randomUUID))]
+    (println id)
+    (err/err->> {:org "tracing-test" :id id}
+                (with-tracing #(identity [(assoc % :fn01 "fn01") nil]) [:main-fn])
+                (with-tracing #(identity [(assoc % :fn02 "fn02") nil]) [:main-fn :lion01])
+                (with-tracing #(identity [(assoc % :fn03 "fn03") nil]) [:main-fn :lion02])
+                (with-tracing #(identity [(assoc % :fn04 "fn04") nil]) [:main-fn :lion03] {:lion03 "a-lion"})
+                (with-tracing #(identity [(assoc % :fn05 "fn05") nil]) [:main-fn :lion04])
+
+                (with-tracing #(identity [(assoc % :fn-child02 "fn-child02") nil]) [:lion04 :eagle01])
+                ;; test with exception
+                ;; (with-tracing (fn [_] (throw (Exception. "a nasty exception"))) [:lion04 :eagle02] {:eagle02 "an-eagle"})
+                ;; test it when the function return [nil "error"]
+                ;; (with-tracing (fn [_] [nil "a nasty error"]) [:lion04 :eagle02] {:eagle02 "an-eagle"})
+                (with-tracing #(identity [(assoc % :fn-child03 "fn-child03") nil]) [:lion04 :eagle02] {:eagle02 "an-eagle"})
+                (with-tracing #(identity [(assoc % :fn-child04 "fn-child04") nil]) [:lion04 :eagle03])
+
+                (with-tracing #(identity [% nil]) [:eagle03 :bird01])
+                (with-tracing #(identity [% nil]) [:eagle03 :bird02])
+                (with-tracing #(identity [% nil]) [:eagle03 :bird03] {:bird03 "a-bird"})
+
+                (with-tracing-end))))


### PR DESCRIPTION
- Add tracing to track running tasks on agents
- Add revision and version to tracing (helps to identify which versions of agent are running)

I had problems implementing the link with the API. The honeycomb tracing API doesn't return an `io.opentracing.Tracer`, instead it returns a SdkTracer, the exemple:
```javascript
tracer.buildSpan(operationName).asChildOf(parentSpan)
```

Will not work because `.build()` doesn't return `io.opentracing.Tracer`, instead it returns a SdkTracer that doesn't have the implements the functions mentioned, I've tried other approach but without success also, need more time to understand how to solve this.

Found a honeycomb clojure library, but didn't test it:
https://github.com/conormcd/clj-honeycomb

Another implementation of opentracing wich could work, but it falls to the same problem mentioned, I could not use this library because the honeycomb sdk doesn't return a tracer implementation:

https://github.com/alvinfrancis/opentracing-clj#tracer

Ref: https://github.com/honeycombio/honeycomb-opentelemetry-java/blob/main/sdk/src/main/java/io/honeycomb/opentelemetry/OpenTelemetryConfiguration.java#L315-L318

---

When running the agent, the following trace will be created:

![image](https://user-images.githubusercontent.com/586235/134012988-15348f6c-984a-4a76-80b1-ee4b43ac4bcb.png)

Looking for a task-id in the honeycomb it will return the 2 traces:

![image](https://user-images.githubusercontent.com/586235/134013140-1ef90f2b-42c2-461d-9cf1-2e7cf0a452e1.png)

If the task returns an error it will log in the tracing in the attribute `message` of the span, however if the task `fail-with-msg...` func it will not return an error (I wonder if it makes sense to log this).