### PR TITLE
Force shutdown agent and logging improvements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,8 +20,7 @@
                  [io.honeycomb/honeycomb-opentelemetry-sdk "0.4.0"]
 
                  ; logging
-                 [cambium "0.8.1"]
-                 [cambium/cambium.core "1.0.0"]
+                 [cambium/cambium.core "1.1.0"]
                  [cambium/cambium.codec-cheshire "1.0.0"]
                  [cambium/cambium.logback.json "0.4.4"]
 

--- a/src/agent/clients.clj
+++ b/src/agent/clients.clj
@@ -55,7 +55,7 @@
 (defmulti add-delay (fn [data] (not (nil? (:delay data)))))
 
 (defmethod add-delay true [data]
-  (log/info (format "Waiting %s seconds..." (:delay data)))
+  (log/info (format "Waiting %s milliseconds..." (:delay data)))
   (Thread/sleep (:delay data)))
 
 (defmethod add-delay false [_])

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -1,5 +1,7 @@
 (ns agent.core
   (:require [cambium.core :as log]
+            [cambium.logback.json.flat-layout :as flat]
+            [cambium.codec :as codec]
             [agent.clients :as _]
             [version.version :refer [app-version git-revision]]
             [agent.http-poller :as http]
@@ -10,8 +12,17 @@
 (def tags (System/getenv "TAGS"))
 
 (defn -main [& _]
+  (flat/set-decoder! codec/destringify-val)  ; configure backend with the codec
   (log/info (format "Starting agent tagged with [%s]" tags))
   (log/info (format "version=%s, revision=%s" app-version git-revision))
+
+  (alter-var-root #'cambium.core/transform-context
+                  (fn [_]
+                    (fn [context]
+                      (-> context
+                          (assoc :version app-version
+                                 :tags tags)))))
+
   ; mount clients
   (mount/start)
   (grcp/listen-subscription)

--- a/src/agent/grpc_subscriber.clj
+++ b/src/agent/grpc_subscriber.clj
@@ -25,10 +25,12 @@
 
 (defn when-closed [future-to-watch callback]
   (future (callback
-            (try
-              @future-to-watch
-              (catch Exception e
-                (log/warn (format "subscription ended with message: %s" (:message (ex-data (.getCause e))))))))))
+           (try
+             @future-to-watch
+             (catch Exception e
+               (log/warn (format "subscription ended with message:%s cause:%s"
+                                 (.getMessage e)
+                                 (:message (ex-data (.getCause e))))))))))
 
 (defn subscribe []
   (subscription-channel! (async/chan 1))


### PR DESCRIPTION
- Force shutdown of agent when a connection issue is detected
- Updated `cambium/cambium.core` library and removed `cambium` (unused library)
- Add logging context tags and version
- Increase poll internal of http poller
- Add .getMessage when subscription ended
- Fix codec logging issues

Before:

```
"ns":"\"agent.grpc-subscriber\""
```

After: 

```
"ns":"agent.grpc-subscriber"
```