### PR TITLE
Add option to disable aws secret manager

### DIFF
--- a/src/agent/clients.clj
+++ b/src/agent/clients.clj
@@ -10,6 +10,7 @@
 (def token (System/getenv "TOKEN"))
 (def api-url (or (System/getenv "API_URL") "https://api.runops.io"))
 (def grpc-url (or (System/getenv "GRPC_URL") "https://api.runops.io:8443"))
+(def disable-aws-secret-manager (= (System/getenv "AWS_SECRET_MANAGER") "false"))
 (def grpc-ssl (Boolean/valueOf (or (System/getenv "GRPC_SSL") "true")))
 
 (defn decode-base64 [str]
@@ -75,12 +76,14 @@
 
 (defn aws-client-start []
   (try
-    (SecretsManagerClient/create)
+    (when-not disable-aws-secret-manager
+      (log/info "Initializing AWS Secret Manager ...")
+      (SecretsManagerClient/create))
     (catch Exception e
       (log/warn (format "Could not start AWS client with error: %s" e)))))
 
 (defn aws-client-stop []
   (try
-    (.close aws-client)
+    (when-not disable-aws-secret-manager (.close aws-client))
     (catch Exception e
       (log/warn (format "Could not close AWS client with error: %s" e)))))


### PR DESCRIPTION
This will prevent output the message above when the user doesn't have integration with AWS Secret Manager:

```
Could not start AWS client with error: software.amazon.awssdk.core.exception.SdkClientException: Unable to load region from any of the providers in the chain software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain@542aa32a: [software.amazon.awssdk.regions.providers.SystemSettingsRegionProvider@74f17bb8: Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region)., software.amazon.awssdk.regions.providers.AwsProfileRegionProvider@27ad03: No region provided in profile: default, software.amazon.awssdk.regions.providers.InstanceProfileRegionProvider@5dcaa37a: Unable to contact EC2 metadata service.
```

Configuring the environment `AWS_SECRET_MANAGER=false` will turn off the aws client, making it by default on (to maintain compatibility)

---

This approach has the downside of relying in an environment variable to turn off this feature, in the other hand relying on an implicit approach it seems better, which could be implemented verifying if a given AWS credentials is set ($HOME/.aws, env variables, etc), but it also could be error prone, because for each authentication method we need to inspect if the user has configured proper credentials:
- Does $HOME/.aws directory exists and has credentials on it?
- The AWS environment variable is set?
- In some cases the credentials are bound to an EC2 instance (metadata service)