### PR TITLE
Save script to run using rails instead of sending stdout to script

### DIFF
--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -193,8 +193,10 @@
         ;; on local dependencies tools like base64.
         ecs-command (format
                      (str "/bin/sh -c \""
-                          "DISABLE_SPRING=1 rails runner 'require \"'\"base64\"'\"; puts Base64.decode64(\"'\"%s\"'\")' "
-                          "> /tmp/runops-script && DISABLE_SPRING=1 rails runner /tmp/runops-script"
+                          (when (get-in task [:secrets :ECS_DEBUG]) "set -x; ")
+                          "DISABLE_SPRING=1 rails runner 'require \"'\"base64\"'\";"
+                          "File.write(\"'\"/tmp/runops-script\"'\", Base64.decode64(\"'\"%s\"'\"))'"
+                          "&& DISABLE_SPRING=1 rails runner /tmp/runops-script"
                           "\"")
                      base64-script)]
     (aws-ecs-exec ecs-command task)))


### PR DESCRIPTION
It prevents having mixed output with rails runner command when decoding script as base64
- Add ECS_DEBUG flag for debugging the output of rails runner ...