### PR TITLE
Add PATH env variable to load proper python modules to sys.path

### DIFF
--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -145,7 +145,8 @@
 (def sh-python
   (fn [task] (shell/sh "python3"
                        :in (:script task)
-                       :env (clojure.walk/stringify-keys (:secrets task)))))
+                       :env (assoc (clojure.walk/stringify-keys (:secrets task))
+                                   :PATH (System/getenv "PATH")))))
 
 (def sh-rails
   (fn [task] (shell/sh "rails" (:script task))))


### PR DESCRIPTION
Due to the change of the image (debian -> ubuntu), the python executable was not loading properly the modules, this caused error when importing installed modules like `boto3`. Injecting the `PATH` variable when executing python solved the problem.

Fix a breaking change due to introduction of a new base image (ubuntu): https://github.com/runopsio/agent/commit/7bf35b4fcd6a6cbac57dd0dad3a55e4c62d30a17