### PR TITLE
Improve sentry Logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [org.ow2.asm/asm "8.0.1"]
 
                  ; monitoring
-                 [io.sentry/sentry-logback "5.0.1"]
+                 [io.sentry/sentry-clj "5.2.158"]
                  [io.honeycomb/honeycomb-opentelemetry-sdk "0.4.0"]
 
                  ; logging

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -14,15 +14,6 @@
             </layout>
         </encoder>
     </appender>
-
-    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-        <options>
-            <dsn>https://7bee01d63c85471188c9157e62c79771@o919346.ingest.sentry.io/5863449</dsn>
-        </options>
-        <minimumEventLevel>WARN</minimumEventLevel>
-        <minimumBreadcrumbLevel>DEBUG</minimumBreadcrumbLevel>
-    </appender>
-
     <logger name="protojure.internal.grpc.client.providers.http2.jetty" level="off"/>
     <logger name="protojure.internal.grpc.client.providers.http2.core" level="off"/>
     <root level="info">

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -13,9 +13,7 @@
 
 (defn -main [& _]
   (flat/set-decoder! codec/destringify-val)  ; configure backend with the codec
-  (log/info (format "Starting agent tagged with [%s]" tags))
-  (log/info (format "version=%s, revision=%s" app-version git-revision))
-
+  (log/info {:version app-version :revision git-revision :tags tags} "Starting agent")
   (alter-var-root #'cambium.core/transform-context
                   (fn [_]
                     (fn [context]
@@ -27,4 +25,3 @@
   (mount/start)
   (grcp/listen-subscription)
   (http/poll))
-

--- a/src/agent/grpc_subscriber.clj
+++ b/src/agent/grpc_subscriber.clj
@@ -3,8 +3,8 @@
             [agent.clients :as clients]
             [agent.agent :as agent]
             [io.grpc.Agent.client :as agent-client]
-            [cambium.core :as log])
-  (:import io.sentry.Sentry))
+            [cambium.core :as log]
+            [sentry.logger :refer [sentry-task-logger]]))
 
 (def grpc-channels (atom {}))
 
@@ -21,7 +21,7 @@
     (async/go (agent/run-task (assoc task :mode :grpc)))
     (catch Exception e
       (log/error (format "failed to run task id %s command with error: %s" (:id task) e))
-      (Sentry/captureException e))))
+      (sentry-task-logger e task "failed to process message"))))
 
 (defn when-closed [future-to-watch callback]
   (future (callback

--- a/src/agent/secrets.clj
+++ b/src/agent/secrets.clj
@@ -1,5 +1,6 @@
 (ns agent.secrets
   (:require [cambium.core :as log]
+            [sentry.logger :refer [sentry-task-logger]]
             [clojure.data.json :as json]
             [clj-http.client :as client]
             [agent.clients :as clients]
@@ -189,7 +190,7 @@
 
 (defmethod format-by-db :default [task]
   (do (log/warn (format "not mapped vault db type '%s'" (:type task)))
-      (Sentry/captureMessage (format "A customer tried to get vault secrets for a not mapped db type: %s" (:type task)))
+      (sentry-task-logger task "A customer tried to get vault secrets for a not mapped db type")
       [nil (format "not mapped vault db type '%s'" (:type task))]))
 
 (defn merge-user-pass [task keys]

--- a/src/runtime/data.clj
+++ b/src/runtime/data.clj
@@ -1,0 +1,45 @@
+(ns runtime.data
+  (:require [clojure.java.shell :as shell]
+            [version.version :refer [app-version git-revision]]))
+
+(def envs {:tags (System/getenv "TAGS")})
+
+(defn- sh [& args]
+  (try
+    (apply shell/sh args)
+    (catch Exception _
+      nil)))
+
+(defn- get-machine-id []
+  (let [stdout (:out (sh "cat" "/sys/class/dmi/id/product_uuid"))]
+    (clojure.string/trim stdout)))
+
+(defn- get-kernel-version []
+  (let [stdout (:out (sh "uname" "-s" "-r"))]
+    (clojure.string/trim stdout)))
+
+(defn- get-distro-name []
+  (let [stdout (:out (sh "cat" "/etc/issue.net"))]
+    (clojure.string/trim stdout)))
+
+(defn- get-hostname []
+  (let [stdout (:out (sh "hostname"))]
+    (clojure.string/trim stdout)))
+
+(def runtime-data
+  (let [machine-id (get-machine-id)
+        distro-name (get-distro-name)
+        kernel-version (get-kernel-version)
+        hostname (get-hostname)
+        machine-id (if (clojure.string/blank? machine-id) "runpos:unknown" machine-id)
+        distro-name (if (clojure.string/blank? distro-name) "runpos:unknown" distro-name)
+        kernel-version (if (clojure.string/blank? kernel-version) "runpos:unknown" kernel-version)
+        hostname (if (clojure.string/blank? hostname) "runpos:unknown" hostname)]
+    {:machine-id machine-id
+     :distro distro-name
+     :kernel-version kernel-version
+     :hostname hostname
+     :git-revision git-revision
+     :app-version app-version
+     :tags (get envs :tags "runpos:unknown")}))
+

--- a/src/sentry/logger.clj
+++ b/src/sentry/logger.clj
@@ -1,0 +1,36 @@
+(ns sentry.logger
+  (:require [sentry-clj.core :as sentry]
+            [version.version :refer [app-version]]
+            [runtime.data :refer [runtime-data]]
+            [mount.core :refer [defstate]]
+            [cambium.core :as log]))
+
+(defstate sentry-init
+  :start (do
+           (log/info "Initializing logger")
+           (sentry/init! "https://7bee01d63c85471188c9157e62c79771@o919346.ingest.sentry.io/5863449"
+                         {:environment "production"
+                          :debug false
+                          :release app-version})))
+
+(defn sentry-logger
+  "Log exceptions to Sentry with metadata runtime data as tags.
+  event - Contain the full event.
+  See more: https://github.com/getsentry/sentry-clj/tree/5.2.158"
+  [event]
+  (sentry/send-event
+   (assoc event :tags (conj (:tags event) (dissoc runtime-data :app-version)))))
+
+(defn sentry-task-logger
+  "Extract useful information from a runops task and add as a context"
+  ([ex task message]
+   (sentry-logger {:message message
+                   :throwable ex
+                   :tags (merge {:mode (name (get task :mode "runops:unknown"))
+                                 :type (get task :type "runops:unknown")
+                                 :org (get task :org "runops:unknown")
+                                 :task-id (get task :id "runops:unknown")}
+                                (when-not (clojure.string/blank? (:secret-provider task))
+                                  {:secret-provider (:secret-provider task)}))}))
+  ([task message]
+   (sentry-task-logger nil task message)))


### PR DESCRIPTION
Add more useful information to classify exceptions on sentry with task data like:

- task-id
- type (command type)
- agent version
- agent revision
- mode (http poller or grpc)
- OS runtime data (kernel version, hostname, distro, machine-id)

---

- Remove logback in flavor of https://github.com/getsentry/sentry-clj/tree/5.2.158
- Obtain runtime data of the system using shell

## Before
![image](https://user-images.githubusercontent.com/586235/138469963-97de4401-6b87-4e41-9716-7389668c871c.png)

## After
![image](https://user-images.githubusercontent.com/586235/138469443-8909b1c1-3047-4149-a77c-168f47261ef2.png)

> TODO: Need to add `org` attribute in API to provide as context to sentry

