### PR TITLE
add secrets as env vars to bash type

### DIFF
--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -32,7 +32,9 @@
 
 (def sh-bash
   (fn [task] (let [args (clojure.string/split (:script task) #" ")]
-               (apply shell/sh args))))
+               (shell/sh args
+                         :env (assoc (clojure.walk/stringify-keys (:secrets task))
+                                     :PATH (System/getenv "PATH"))))))
 
 (def sh-hashicorp-vault
   (fn [task] (let [script-items (clojure.string/split (:script task) #" ")


### PR DESCRIPTION
----

Bash type can't access secrets today, rendering it mostly unusable. I understand we have open questions and limitations about making this type available. But I can see some usefulness in it even with these limitations. We should evolve this later and add documentations alerting users about the risks of exposing a plain bash type to users. This is not the scope of this task, as we are just fixing something that is expected for any Runops Target: access secrets.