### PR TITLE
Add JWT validation

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -54,4 +54,4 @@ jobs:
         run: make docker-build
       
       - name: Publish Docker Image
-        run: make docker-push
+        run: make docker-mutable-push

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,8 @@
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/core.async "1.3.610"]
                  [org.clojure/data.json "1.0.0"]
+                 [buddy/buddy-core "1.10.1"]
+                 [buddy/buddy-sign "3.4.1"]
 
                  ; gRPC
                  [protojure "1.5.11"]

--- a/resources/agent.proto
+++ b/resources/agent.proto
@@ -36,6 +36,7 @@ message TaskResponse {
   string x_b3_trace_id = 8;
   string x_b3_parent_span_id = 9;
   string custom_command = 10;
+  string token = 11;
 }
 
 message LogsRequest {

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -5,7 +5,7 @@
             [agent.clients :as _]
             [version.version :refer [app-version git-revision]]
             [agent.http-poller :as http]
-            [agent.grpc-subscriber :as grcp]
+            [agent.grpc-subscriber :as grpc]
             [backoff.time :as backoff]
             [runtime.init :as init]
             [mount.core :as mount])
@@ -27,20 +27,20 @@
   (configure-logger)
 
   (let [runtime-config (init/fetch-agent-config)
+        _ (-> (mount/with-args runtime-config) mount/start)
+        well-known-jwks (init/fetch-jwks-pubkeys)
         grpc-channel-timeout (get-in runtime-config [:connection-config :grpc-connect-channel-timeout])
         backoff-grpc-connect-subscribe (get-in runtime-config [:connection-config :backoff-grpc-connect-subscribe])
         backoff-http-poll (get-in runtime-config [:connection-config :backoff-http-poll])
         grpc-channel-timeout (backoff/parse-default grpc-channel-timeout (backoff/min->ms 5))
         backoff-grpc-connect-subscribe (backoff/parse-default backoff-grpc-connect-subscribe (backoff/sec->ms 5))
         backoff-http-poll (backoff/parse-default backoff-http-poll (backoff/sec->ms 15))]
-    (-> (mount/with-args runtime-config)
-        mount/start)
     (log/info (format "Agent config id=[%s] loaded with success. Backoff grpc-channel-timeout=[%s] grpc-conn-subscribe=[%s] http-poll=[%s] "
                       (:id runtime-config)
                       grpc-channel-timeout
                       backoff-grpc-connect-subscribe
                       backoff-http-poll))
-    (grcp/listen-subscription grpc-channel-timeout backoff-grpc-connect-subscribe)
+    (grpc/listen-subscription well-known-jwks grpc-channel-timeout backoff-grpc-connect-subscribe)
     (http/poll backoff-http-poll)))
 
 (defn run-grpc-dev []
@@ -48,17 +48,14 @@
 
   (log/info "Running in gRPC mode - development mode")
   (let [runtime-config (init/fetch-agent-config)
+        _ (-> (mount/with-args runtime-config) mount/start)
+        well-known-jwks (init/fetch-jwks-pubkeys)
         grpc-channel-timeout (get-in runtime-config [:connection-config :grpc-connect-channel-timeout])
         backoff-grpc-connect-subscribe (get-in runtime-config [:connection-config :backoff-grpc-connect-subscribe])
-        backoff-http-poll (get-in runtime-config [:connection-config :backoff-http-poll])
         grpc-channel-timeout (backoff/parse-default grpc-channel-timeout (backoff/min->ms 5))
-        backoff-grpc-connect-subscribe (backoff/parse-default backoff-grpc-connect-subscribe (backoff/sec->ms 5))
-        backoff-http-poll (backoff/parse-default backoff-http-poll (backoff/sec->ms 15))]
-    (-> (mount/with-args runtime-config)
-        mount/start)
-    (log/info (format "Agent config id=[%s] loaded with success. Backoff grpc-channel-timeout=[%s] grpc-conn-subscribe=[%s] http-poll=[%s] "
+        backoff-grpc-connect-subscribe (backoff/parse-default backoff-grpc-connect-subscribe (backoff/sec->ms 5))]
+    (log/info (format "Agent config id=[%s] loaded with success. Backoff grpc-channel-timeout=[%s] grpc-conn-subscribe=[%s] "
                       (:id runtime-config)
                       grpc-channel-timeout
-                      backoff-grpc-connect-subscribe
-                      backoff-http-poll))
-    (grcp/listen-subscription grpc-channel-timeout backoff-grpc-connect-subscribe)))
+                      backoff-grpc-connect-subscribe))
+    (grpc/listen-subscription well-known-jwks grpc-channel-timeout backoff-grpc-connect-subscribe)))

--- a/src/agent/http_poller.clj
+++ b/src/agent/http_poller.clj
@@ -4,6 +4,7 @@
             [clj-http.client :as client]
             [agent.clients :as clients]
             [agent.agent :as agent]
+            [runtime.data :refer [runtime-data]]
             [camel-snake-kebab.extras :as cske]
             [camel-snake-kebab.core :as csk]
             [clojure.core.async :as async]))
@@ -21,8 +22,10 @@
                                   :query-params poll-params})
             tasks (map #(cske/transform-keys csk/->kebab-case %) (read-string (:body response)))]
         (when (> (count tasks) 0)
-          (log/info (format "found %s task(s) to run" (count tasks)))
-          (doall (pmap #(agent/run-task (assoc % :mode :poll)) tasks))))
+          (if (:jwk-verify runtime-data) nil
+              (do
+                (log/info (format "found %s task(s) to run" (count tasks)))
+                (doall (pmap #(agent/run-task (assoc % :mode :poll)) tasks))))))
       (catch java.io.EOFException e
         (log/error (format "failed to poll tasks with error: %s" e))
         (sentry-logger {:message "failed to poll tasks" :throwable e})

--- a/src/crypto/sign.clj
+++ b/src/crypto/sign.clj
@@ -1,0 +1,35 @@
+(ns crypto.sign
+  (:require [buddy.core.keys :as keys]
+            [clojure.data.json :as json]
+            [buddy.sign.jwt :as jwt]
+            [buddy.core.codecs.base64 :as base64]
+            [clojure.walk :refer [keywordize-keys]]))
+
+(defn- parse-token-header [jwt-token]
+  (->> jwt-token
+       (#(clojure.string/split % #"\."))
+       (#(if (< (count %) 3) (throw (ex-info "malformed jwt token" {:type :validation :cause :malformed-token}))
+             %))
+       (#(base64/decode (first %)))
+       (String.)
+       (json/read-str)
+       (keywordize-keys)))
+
+(defn verify-sig
+  "Parse jwt token and find the correspond kid in the jwks structure and returns a map with all claims"
+  [jwt-token well-known-jwks]
+  (let [token-header (parse-token-header jwt-token)
+        jwt-kid (:kid token-header)
+        jwk-pubkey (first (filter #(= jwt-kid (:kid %)) (:keys well-known-jwks)))
+        pubkey (when (not (nil? jwk-pubkey)) (keys/jwk->public-key jwk-pubkey))
+        alg (case (:alg token-header)
+              "RS256" :rs256
+              "ES256" :es256
+              nil)]
+    (cond
+      (nil? alg) (throw (ex-info (format "jwt token algorithm [%s] not supported" (:alg token-header))
+                                 {:type :validation :cause :alg}))
+      (nil? pubkey) (throw (ex-info (format "jwt token kid [%s] not found in well-known jwks" jwt-kid)
+                                    {:type :validation :cause :kid}))
+      :else (assoc (jwt/unsign jwt-token pubkey {:alg alg})
+                   :header token-header))))

--- a/src/io/grpc.cljc
+++ b/src/io/grpc.cljc
@@ -470,9 +470,10 @@
 ;-----------------------------------------------------------------------------
 ; TaskResponse
 ;-----------------------------------------------------------------------------
-(defrecord TaskResponse-record [config custom-command x-b3-parent-span-id id secret-provider script secret-path type secret-mapping x-b3-trace-id]
+(defrecord TaskResponse-record [token config custom-command x-b3-parent-span-id id secret-provider script secret-path type secret-mapping x-b3-trace-id]
   pb/Writer
   (serialize [this os]
+    (serdes.core/write-String 11  {:optimize true} (:token this) os)
     (serdes.core/write-String 7  {:optimize true} (:config this) os)
     (serdes.core/write-String 10  {:optimize true} (:custom-command this) os)
     (serdes.core/write-String 9  {:optimize true} (:x-b3-parent-span-id this) os)
@@ -487,6 +488,7 @@
   (gettype [this]
     "io.grpc.TaskResponse"))
 
+(s/def :io.grpc.TaskResponse/token string?)
 (s/def :io.grpc.TaskResponse/config string?)
 (s/def :io.grpc.TaskResponse/custom-command string?)
 (s/def :io.grpc.TaskResponse/x-b3-parent-span-id string?)
@@ -497,8 +499,8 @@
 (s/def :io.grpc.TaskResponse/type string?)
 (s/def :io.grpc.TaskResponse/secret-mapping string?)
 (s/def :io.grpc.TaskResponse/x-b3-trace-id string?)
-(s/def ::TaskResponse-spec (s/keys :opt-un [:io.grpc.TaskResponse/config :io.grpc.TaskResponse/custom-command :io.grpc.TaskResponse/x-b3-parent-span-id :io.grpc.TaskResponse/id :io.grpc.TaskResponse/secret-provider :io.grpc.TaskResponse/script :io.grpc.TaskResponse/secret-path :io.grpc.TaskResponse/type :io.grpc.TaskResponse/secret-mapping :io.grpc.TaskResponse/x-b3-trace-id ]))
-(def TaskResponse-defaults {:config "" :custom-command "" :x-b3-parent-span-id "" :id 0 :secret-provider "" :script "" :secret-path "" :type "" :secret-mapping "" :x-b3-trace-id "" })
+(s/def ::TaskResponse-spec (s/keys :opt-un [:io.grpc.TaskResponse/token :io.grpc.TaskResponse/config :io.grpc.TaskResponse/custom-command :io.grpc.TaskResponse/x-b3-parent-span-id :io.grpc.TaskResponse/id :io.grpc.TaskResponse/secret-provider :io.grpc.TaskResponse/script :io.grpc.TaskResponse/secret-path :io.grpc.TaskResponse/type :io.grpc.TaskResponse/secret-mapping :io.grpc.TaskResponse/x-b3-trace-id ]))
+(def TaskResponse-defaults {:token "" :config "" :custom-command "" :x-b3-parent-span-id "" :id 0 :secret-provider "" :script "" :secret-path "" :type "" :secret-mapping "" :x-b3-trace-id "" })
 
 (defn cis->TaskResponse
   "CodedInputStream to TaskResponse"
@@ -506,6 +508,7 @@
   (->> (tag-map TaskResponse-defaults
          (fn [tag index]
              (case index
+               11 [:token (serdes.core/cis->String is)]
                7 [:config (serdes.core/cis->String is)]
                10 [:custom-command (serdes.core/cis->String is)]
                9 [:x-b3-parent-span-id (serdes.core/cis->String is)]

--- a/src/runtime/data.clj
+++ b/src/runtime/data.clj
@@ -3,6 +3,7 @@
             [version.version :refer [app-version git-revision]]))
 
 (def envs {:tags (System/getenv "TAGS")})
+(def jwk-url (System/getenv "JWK_URL"))
 
 (defn- sh [& args]
   (try
@@ -32,6 +33,8 @@
         kernel-version (get-kernel-version)
         hostname (get-hostname)
         tags (:tags envs)
+        jwk-verify (not (clojure.string/blank? jwk-url))
+        jwk-url (if (clojure.string/blank? jwk-url) "runops:null" jwk-url)
         machine-id (if (clojure.string/blank? machine-id) "runops:null" machine-id)
         distro-name (if (clojure.string/blank? distro-name) "runops:null" distro-name)
         kernel-version (if (clojure.string/blank? kernel-version) "runops:null" kernel-version)
@@ -41,6 +44,8 @@
      :distro distro-name
      :kernel-version kernel-version
      :hostname hostname
+     :jwk-verify jwk-verify
+     :jwk-url jwk-url
      :git-revision git-revision
      :app-version app-version
      :tags tags}))

--- a/src/runtime/init.clj
+++ b/src/runtime/init.clj
@@ -5,8 +5,7 @@
             [backoff.time :as backoff]
             [clojure.data.json :as json]
             [clj-http.client :as client]
-            [sentry.logger :refer [sentry-logger
-                                   sentry-task-logger]]
+            [sentry.logger :refer [sentry-logger]]
             [clojure.walk :refer [stringify-keys keywordize-keys]]
             [runtime.data :refer [runtime-data jwk-url]]))
 

--- a/src/runtime/init.clj
+++ b/src/runtime/init.clj
@@ -3,8 +3,12 @@
             [io.grpc.Agent.client :as agent-client]
             [cambium.core :as log]
             [backoff.time :as backoff]
-            [clojure.walk :refer [stringify-keys]]
-            [runtime.data :refer [runtime-data]]))
+            [clojure.data.json :as json]
+            [clj-http.client :as client]
+            [sentry.logger :refer [sentry-logger
+                                   sentry-task-logger]]
+            [clojure.walk :refer [stringify-keys keywordize-keys]]
+            [runtime.data :refer [runtime-data jwk-url]]))
 
 (def ^:private send-event-timeout-ms (backoff/sec->ms 15))
 (def ^:private backoff-max-attempts-ms (backoff/min->ms 5))
@@ -51,3 +55,19 @@
             runtime-config)
           (do (log/warn (format "Unable to retrieve runtime config, attempt [%s/6]" (inc count)))
               (recur (inc count))))))))
+
+(defn fetch-jwks-pubkeys
+  "keywordize-keys of a jwk public key structure from an auth provider.
+   In case of error fetching the public keys, the app will hang"
+  []
+  (if-not
+   (:jwk-verify runtime-data) nil
+   (try
+     (->> (:body (client/get jwk-url))
+          json/read-str
+          keywordize-keys)
+     (catch Exception e
+       (log/error {:jwk-url jwk-url} e "failed to obtain JWK public keys")
+       ;; passing the :throwable here strangely doesn't work 
+       (sentry-logger {:message (format "failed to obtain JWK public keys, ex-info: %s" e)})
+       (System/exit 1)))))

--- a/src/sentry/logger.clj
+++ b/src/sentry/logger.clj
@@ -30,7 +30,7 @@
   See more: https://github.com/getsentry/sentry-clj/tree/5.2.158"
   [event]
   (sentry/send-event
-   (assoc event :tags (conj (:tags event) (dissoc runtime-data :app-version)))))
+   (assoc event :tags (conj (get event :tags {}) (dissoc runtime-data :app-version)))))
 
 (defn sentry-task-logger
   "Extract useful information from a runops task and add as a context"

--- a/test/crypto/sign_test.clj
+++ b/test/crypto/sign_test.clj
@@ -1,0 +1,156 @@
+(ns crypto.sign-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [crypto.sign :as crypto]
+            [buddy.core.keys :refer [private-key public-key public-key->jwk]]
+            [clojure.java.io :refer [input-stream]]
+            [buddy.sign.jwt :as jwt]))
+
+;; openssl genrsa -out privkey.pem 2048
+(def rsa256-privkey-01 "-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAs83RFJEGC08kmHQGqSlDSiRhrjwDRpNHHuDs17NZVEXCjcz8
+yI2BJl4EPZiNV2jJ6GlAd4kUTzIsiPefklAPJT7U4N+4/MYjE+/8W+C5oV/UaFrs
+cZO7uIZy7h34oT4N4CXRaZJ0mkMR/Bqxxx9AVWuei4QdPT1dMmWvZCVG2E3+TSwt
+qwLsb+/9Ou/RiC1B0BiHJxH46UNmsm+yf1e2nuheseE5BKhxhU7zWAzht1Pql/eY
+vYaK8IqWb6aV+JVpgr1qC1uK5FPw1KWBkCXdMtF7dJ1lL9tszB7VqiFC5Do/lW1w
+eBJkxUWX/c21PNkMR+MrEInJMADvqQiRHme4/wIDAQABAoIBAAh8XTLASW29NXfw
+eeP/64oTP3zuniT1jHS7ntHrR/r/M9hnZUK90uuRoleZ3InUizrpxL4ffRLjxlBM
+h35rQtu6JGfchyl+3Gbze5CGgZxJHogySlht5X0m80OjrHlHqXX7su9tlw00vyOL
+yvof0nR1mMzy1kJuo/hd7jImxDovF9MQNUQxZQ4QACiVldvw78ekf9aeUhhjV1jn
+wB8gQjCOuTLP/5z0mAKLZ6Fncvc2d5/rCn3xY4SkOIcn2R23oPO4vDu7h06JxRx5
+pykY+xuKpSOjQo7HncvUi5vk78Jm5IzM+PuVb5w9kwX7wDqzPhuKXZs1laJlnmS8
+Sbo2AMkCgYEA54PuRVNNobv36kM7TWwNMkcABU1PI5lkDcQEjb9ll4zE/3kv3mIZ
+JI7Q/lwkAe4uI7dSjH176TnVAMaPfaH4mINu/phtC6uUPJG2n8TfeuOEdhhbltJj
+joW0bkmYKgnBWcgDCn1xS5av468yK2+bBEEcqgWzlZOsIcKodBn/roMCgYEAxtHY
+0jXiYS2MygBAW0MK+mHCDuBzuy57I0cN8fDUducGAno6dvH/3gr76ihEOAs+NO0r
+mAu+CJdcraHGii3+rMyDT9lAhC6lFP8VUPiz3lXG9sUXKiapZfoTYPe06OcqG2Dd
+NwD3vWtnVSk3H6gKZntwP4aO86IFcpP3IDQvgtUCgYEAg9GPojNbOWJwNxdOtbd3
+EBBzB5HMJKXa3SelvBulOZPyOtACnGlYjYMvphRKgDrgVH+15b4xBktiZ02nN844
+YIY9dYLOW922yoHg7LlI0YynyCH4TDjAbM7ePAl1NUJWr8r9SETCdFp5DXecZjTm
+m5aDPp9+cAUj9hkClxCSjwcCgYA9AG3SMY4/2sXzxJf6aFuZ7xyni952dBB8BnUU
+4puNz9xcLjx5+k5TRnN8qNYli+2ON6bEg/XOlQJuk9Bi3THiuu0fNr1A0T79bjaQ
+HX6ynQbq+BXfbPVUwKHpgpcTTrnwpIu7MKTSjX2q93ZeVCS8xOrv0s1Rm0iomxWb
+3+cj8QKBgQCsonMxwN8brdehbxGU80pKElAjHh0eXom5Br6THP8gl0ykL+7ZbVLV
+QcbtN6OWtt0pTc9vJDOBXqIlNWGJnli8M82MiwA13Jqj2o6FF7bP1vimm+QjIYpx
+D50VmH5EtWwIJ5JLLmKCrzNogokejXnbULMlNjXxWYoM7VBF0cxRRA==
+-----END RSA PRIVATE KEY-----")
+
+;; openssl rsa -pubout -in privkey.pem -out pubkey.pem
+(def rsa256-pubkey-01 "-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs83RFJEGC08kmHQGqSlD
+SiRhrjwDRpNHHuDs17NZVEXCjcz8yI2BJl4EPZiNV2jJ6GlAd4kUTzIsiPefklAP
+JT7U4N+4/MYjE+/8W+C5oV/UaFrscZO7uIZy7h34oT4N4CXRaZJ0mkMR/Bqxxx9A
+VWuei4QdPT1dMmWvZCVG2E3+TSwtqwLsb+/9Ou/RiC1B0BiHJxH46UNmsm+yf1e2
+nuheseE5BKhxhU7zWAzht1Pql/eYvYaK8IqWb6aV+JVpgr1qC1uK5FPw1KWBkCXd
+MtF7dJ1lL9tszB7VqiFC5Do/lW1weBJkxUWX/c21PNkMR+MrEInJMADvqQiRHme4
+/wIDAQAB
+-----END PUBLIC KEY-----")
+
+(def rsa256-pubkey-02 "-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyVbFwEqRhZyFo5SNjZc9
+EcgAnESYr3umih7k4lJ9MK3b5zNOy1cR0Nrfu+X9V061zC7tRMX6Dze91qiWxUAn
+p/M0KDJqWIrsZ6P9fzfcL+sSTs6EAu1uOUguox6Y+AL8CpHdnwlz02eRb+kD1e/s
+tckN1HkNyAQFPEaFA6+aPH4ofRCRVZP5AmLIndJPMcNxp4oU3JGtt1ltbtYftlfk
+iCgyXKn4Xl7bDM3N6A/j3CJ45WciOve1MF7d3XM2/VFHKRhN91Yd5hVQ7rUlYHf2
+5uNlVBEio7g7yAYy52foHluwV4PENwth1BYRDr++/jI1kuoncpTRxLeAtHJWaB7J
+AwIDAQAB
+-----END PUBLIC KEY-----")
+
+(def ecdsa256-privkey "-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIF5uIfbnlIENX6A1h/tmXHTDT7vfbRwOyrw1OEC5oKVoAoGCCqGSM49
+AwEHoUQDQgAEwj5eCxYBlsptuHPxBWkqMIUi95r+joz5YYG7s/OmMCyaLkQrUsLE
+ffbSWH0KaxHS6dV72D2GnuWLPHyvdvQfwA==
+-----END EC PRIVATE KEY-----")
+
+(def ecdsa256-pubkey "-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwj5eCxYBlsptuHPxBWkqMIUi95r+
+joz5YYG7s/OmMCyaLkQrUsLEffbSWH0KaxHS6dV72D2GnuWLPHyvdvQfwA==
+-----END PUBLIC KEY-----")
+
+(deftest validate-algorithms
+  (testing "verify rs256 key pair jwt token"
+    (let [privkey (private-key (input-stream (.getBytes rsa256-privkey-01)))
+          pubkey (public-key (input-stream (.getBytes rsa256-pubkey-01)))
+          exp-kid "expected-kid"
+          jwk-pubkey {:keys [(assoc (public-key->jwk pubkey) :kid exp-kid)]}
+          claims {:iss "https://runops.us.auth0.com/"
+                  :sub "google-oauth2|107828005680090926270"
+                  :iat (quot (System/currentTimeMillis) 1000)
+                  :exp (+ (quot (System/currentTimeMillis) 1000) 2000)}
+          headers {:alg :rs256 :header {:kid exp-kid}}
+          jwt-token (jwt/sign claims privkey headers)]
+      (is (= (crypto/verify-sig jwt-token jwk-pubkey)
+             (assoc claims :header {:alg "RS256" :kid exp-kid})))))
+  (testing "verify ecdsa256 key pair jwt token"
+    (let [privkey (private-key (input-stream (.getBytes ecdsa256-privkey)))
+          pubkey (public-key (input-stream (.getBytes ecdsa256-pubkey)))
+          exp-kid "expected-kid"
+          jwk-pubkey {:keys [(assoc (public-key->jwk pubkey) :kid exp-kid)]}
+          claims {:iss "https://runops.us.auth0.com/"
+                  :sub "google-oauth2|107828005680090926270"
+                  :iat (quot (System/currentTimeMillis) 1000)
+                  :exp (+ (quot (System/currentTimeMillis) 1000) 2000)}
+          headers {:alg :es256 :header {:kid exp-kid}}
+          jwt-token (jwt/sign claims privkey headers)]
+      (is (= (crypto/verify-sig jwt-token jwk-pubkey)
+             (assoc claims :header {:alg "ES256" :kid exp-kid})))))
+  (testing "jwt token algorithm not supported"
+    (let [privkey (private-key (input-stream (.getBytes rsa256-privkey-01)))
+          pubkey (public-key (input-stream (.getBytes rsa256-pubkey-01)))
+          exp-kid "expected-kid"
+          jwk-pubkey {:keys [(assoc (public-key->jwk pubkey) :kid exp-kid)]}
+          headers {:alg :rs512 :header {:kid exp-kid}}
+          jwt-token (jwt/sign {:foo "bar"} privkey headers)]
+      (try (crypto/verify-sig jwt-token jwk-pubkey)
+           (throw (ex-info "it shouldn't accept this algorithm [RS512]!" {}))
+           (catch Exception e
+             (is (= (.getMessage e)
+                    "jwt token algorithm [RS512] not supported"))))))
+  (testing "jwt kid not present inside the jwk structure"
+    (let [privkey (private-key (input-stream (.getBytes rsa256-privkey-01)))
+          pubkey (public-key (input-stream (.getBytes rsa256-pubkey-01)))
+          exp-kid "expected-kid"
+          jwk-pubkey {:keys [(assoc (public-key->jwk pubkey) :kid "unknown-jwk-kid")]}
+          claims {:iss "https://runops.us.auth0.com/"
+                  :sub "google-oauth2|107828005680090926270"
+                  :iat (quot (System/currentTimeMillis) 1000)
+                  :exp (+ (quot (System/currentTimeMillis) 1000) 2000)}
+          headers {:alg :rs256 :header {:kid exp-kid}}
+          jwt-token (jwt/sign claims privkey headers)]
+      (try (crypto/verify-sig jwt-token jwk-pubkey)
+           (throw (ex-info "kid shouldn't be found in well-known jwks!" {}))
+           (catch Exception e
+             (is (= (.getMessage e)
+                    (format "jwt token kid [%s] not found in well-known jwks"
+                            exp-kid)))))))
+  (testing "jwk pubkey doesn't match"
+    (let [privkey (private-key (input-stream (.getBytes rsa256-privkey-01)))
+          pubkey (public-key (input-stream (.getBytes rsa256-pubkey-02)))
+          exp-kid "expected-kid"
+          jwk-pubkey {:keys [(assoc (public-key->jwk pubkey) :kid "expected-kid")]}
+          claims {:iss "https://runops.us.auth0.com/"
+                  :sub "google-oauth2|107828005680090926270"
+                  :iat (quot (System/currentTimeMillis) 1000)
+                  :exp (+ (quot (System/currentTimeMillis) 1000) 2000)}
+          headers {:alg :rs256 :header {:kid exp-kid}}
+          jwt-token (jwt/sign claims privkey headers)]
+      (try (crypto/verify-sig jwt-token jwk-pubkey)
+           (throw (ex-info "the signature shouldn't be valid!" {}))
+           (catch Exception e
+             (is (= (.getMessage e)
+                    "Message seems corrupt or manipulated."))))))
+  (testing "jwt expired"
+    (let [privkey (private-key (input-stream (.getBytes rsa256-privkey-01)))
+          pubkey (public-key (input-stream (.getBytes rsa256-pubkey-01)))
+          exp-kid "expected-kid"
+          jwk-pubkey {:keys [(assoc (public-key->jwk pubkey) :kid "expected-kid")]}
+          claims {:iss "https://runops.us.auth0.com/"
+                  :sub "google-oauth2|107828005680090926270"
+                  :iat 1637932100
+                  :exp 1637932523}
+          headers {:alg :rs256 :header {:kid exp-kid}}
+          jwt-token (jwt/sign claims privkey headers)]
+      (try (crypto/verify-sig jwt-token jwk-pubkey)
+           (throw (ex-info "the jwt token should be expired!" {}))
+           (catch Exception e
+             (is (= (.getMessage e)
+                    "Token is expired (1637932523)")))))))


### PR DESCRIPTION
## Overview
- Add JWT validation when setting the env `JWK_URL=`
- Releasing new versions does not update latest docker images
- Fix bug on tracer when having error on root funcs
- Fix logger bug when using sentry-logger without tags

Applying this feature will validate digital signatures of JWT tokens issued by private key's, this only works when the agent is connection through a gRPC connection and when the user is authenticating with an valid JWT token. Thus the slack tasks is disabled in this mode, executing tasks when the agent has this option enable will return the following error:

```
slack tasks are disabled, try to run it again in the webapp/cli or contact the support.
```

This feature is only useful if the an organization wants to ensure that only authenticated users from their own authentication provider (okta, auth0, ory-hydra, etc) are able to execute tasks in the agent. JWT tokens are used as a session mechanism between the agent and the grpc connection with the API, thus improving the security over what's executed in the private network of organizations.

### Supported Algorithms

- RSA256
- ECDSA256

### Limitations

- Toggling between this feature (JWK_URL=) could be harmful in case of tasks being stored for executing it later (tasks with status=ready).
- HTTP poller is disabled when this option is set
- Slack Tasks / REPL are disabled when this option is set