### PR TITLE
Improve the ability to run more paralell tasks with more efficience

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,11 +10,11 @@
                  [buddy/buddy-sign "3.4.1"]
 
                  ; gRPC
-                 [protojure "1.5.11"]
+                 [protojure "1.5.14"]
                  [protojure/google.protobuf "0.9.1"]
-                 [com.google.protobuf/protobuf-java "3.13.0"]
-                 [org.eclipse.jetty.http2/http2-client "9.4.20.v20190813"]
-                 [org.eclipse.jetty/jetty-alpn-java-client "9.4.28.v20200408"]
+                 [com.google.protobuf/protobuf-java "3.15.6"]
+                 [org.eclipse.jetty.http2/http2-client "9.4.38.v20210224"]
+                 [org.eclipse.jetty/jetty-alpn-java-client "9.4.38.v20210224"]
                  [org.ow2.asm/asm "8.0.1"]
 
                  ; monitoring

--- a/src/agent/clients.clj
+++ b/src/agent/clients.clj
@@ -5,7 +5,6 @@
             [protojure.grpc.client.providers.http2 :as grpc.http2])
   (:import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient))
 
-
 (def tags (System/getenv "TAGS"))
 (def token (System/getenv "TOKEN"))
 (def api-url (or (System/getenv "API_URL") "https://api.runops.io"))
@@ -15,7 +14,6 @@
 
 (defn decode-base64 [str]
   (String. (b64/decode str)))
-
 
 ; gRPC client
 (def grpc-client-atom (atom {}))
@@ -61,11 +59,17 @@
 
 (defmethod add-delay false [_])
 
+(defn disconnect-grpc []
+  (when-let [c (grpc-client)]
+    (try (.disconnect c)
+         (catch Exception _)))
+  (reset! grpc-client-atom {}))
+
 (defn connect-grpc [data]
   (log/info "Trying to connect to gRPC server...")
   (add-delay data)
+  (disconnect-grpc)
   (start-grpc))
-
 
 ; aws secret manager client
 (declare aws-client-start aws-client-stop)

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -40,7 +40,7 @@
                       grpc-channel-timeout
                       backoff-grpc-connect-subscribe
                       backoff-http-poll))
-    (grpc/listen-subscription well-known-jwks grpc-channel-timeout backoff-grpc-connect-subscribe)
+    (future (grpc/listen-subscription well-known-jwks grpc-channel-timeout backoff-grpc-connect-subscribe))
     (http/poll backoff-http-poll)))
 
 (defn run-grpc-dev []

--- a/src/agent/grpc_subscriber.clj
+++ b/src/agent/grpc_subscriber.clj
@@ -8,16 +8,16 @@
             [runtime.data :refer [runtime-data]]
             [sentry.logger :refer [sentry-task-logger]]))
 
-(def queue-info (atom {:tasks #{}}))
+(def queue-info (atom #{}))
 
 (defn queue-length []
-  (count (:tasks @queue-info)))
+  (count @queue-info))
 
 (defn queue-info-add [task-id]
-  (swap! queue-info assoc :tasks (merge (:tasks @queue-info) task-id)))
+  (swap! queue-info (fn [queue] (set (conj queue task-id)))))
 
 (defn queue-info-remove [task-id]
-  (swap! queue-info assoc :tasks (remove #{task-id} (:tasks @queue-info))))
+  (swap! queue-info (fn [queue] (set (remove #{task-id} queue)))))
 
 (def grpc-channels (atom {}))
 
@@ -29,13 +29,17 @@
 
 (defn process-message [task]
   (try
-    (async/go (do (queue-info-add (:id task))
-                  (log/info {:queue (queue-length) :queued-tasks (:tasks @queue-info) :task-id (:id task)}
+    (async/thread (queue-info-add (:id task))
+                  (log/info {:queue (queue-length) :queued-tasks @queue-info :task-id (:id task)}
                             "starting running task async.")
-                  (agent/run-task (assoc task :mode :grpc :jwk-verify (:jwk-verify runtime-data)))
+                  (agent/run-task (assoc task
+                                         :mode :grpc
+                                         :jwk-verify (:jwk-verify runtime-data)
+                                         :queue-lenght (queue-length)))
+
                   (queue-info-remove (:id task))
-                  (log/info {:queue (queue-length) :queued-tasks (:tasks @queue-info) :task-id (:id task)}
-                            "finished running task async.")))
+                  (log/info {:queue (queue-length) :queued-tasks @queue-info :task-id (:id task)}
+                            "finished running task async."))
     (catch Exception e
       (queue-info-remove (:id task))
       (log/error {:task-id (:id task) :queue (queue-length)} e "failed to run task.")
@@ -68,19 +72,21 @@
   (grpc-connect-subscribe {})
 
   (log/info "starting gRPC listener...")
-  (async/go-loop []
+  (loop []
     (if (clients/grpc-client-alive?)
       (let [out-chan (subscription-channel)
             timeout-chan (async/timeout channel-timeout-ms)
-            [msg chan] (async/alts! [out-chan timeout-chan])]
+            [msg chan] (async/alts!! [out-chan timeout-chan])]
         (if (= timeout-chan chan)
           (do (log/info {:queue (queue-length)}
-                        (format "did not receive any ping in past %s minute(s)... restarting gRPC connection"
+                        (format "reached channel timeout [%sm], restarting gRPC connection"
                                 (backoff/ms->min channel-timeout-ms)))
+              (clients/disconnect-grpc)
               (grpc-connect-subscribe {:delay backoff-subscribe-ms}))
           (if msg
             (process-message (assoc msg :well-known-jwks well-known-jwks))
             (do (log/warn {:queue (queue-length)} "gRPC server has closed the subscription channel...")
+                (clients/disconnect-grpc)
                 (grpc-connect-subscribe {:delay backoff-subscribe-ms})))))
       (grpc-connect-subscribe {:delay backoff-subscribe-ms}))
     (recur)))

--- a/src/agent/http_poller.clj
+++ b/src/agent/http_poller.clj
@@ -14,33 +14,32 @@
         (when clients/tags {:tags clients/tags})))
 
 (defn poll-tasks []
-  (async/go
-    (try
-      (let [response (client/get (format "%s/v2/tasks" clients/api-url)
-                                 {:headers {"Authorization" (str "Bearer " clients/token)
-                                            "Accept" "application/edn"}
-                                  :query-params poll-params})
-            tasks (map #(cske/transform-keys csk/->kebab-case %) (read-string (:body response)))]
-        (when (> (count tasks) 0)
-          (if (:jwk-verify runtime-data) nil
-              (do
-                (log/info (format "found %s task(s) to run" (count tasks)))
-                (doall (pmap #(agent/run-task (assoc % :mode :poll)) tasks))))))
-      (catch java.io.EOFException e
-        (log/error (format "failed to poll tasks with error: %s" e))
-        (sentry-logger {:message "failed to poll tasks" :throwable e})
+  (try
+    (let [response (client/get (format "%s/v2/tasks" clients/api-url)
+                               {:headers {"Authorization" (str "Bearer " clients/token)
+                                          "Accept" "application/edn"}
+                                :query-params poll-params})
+          tasks (map #(cske/transform-keys csk/->kebab-case %) (read-string (:body response)))]
+      (when (> (count tasks) 0)
+        (if (:jwk-verify runtime-data) nil
+            (do
+              (log/info (format "found %s task(s) to run" (count tasks)))
+              (doall (pmap #(agent/run-task (assoc % :mode :poll)) tasks))))))
+    (catch java.io.EOFException e
+      (log/error (format "failed to poll tasks with error: %s" e))
+      (sentry-logger {:message "failed to poll tasks" :throwable e})
         ;; this is a workaround to make agent resilient to network issues
-        ;; we saw this issue happening on dock infrastracture.
-        (when (clojure.string/includes? (str (.getMessage e)) "SSL peer shut down incorrectly")
-          (log/warn "agent force shutdown due to connection issues")
-          (System/exit 1)))
-      (catch Exception e
-        (log/error (format "failed to poll tasks with error: %s" e))
-        (sentry-logger {:message "failed to poll tasks" :throwable e})))))
+        ;; we saw this issue happening in some customers
+      (when (clojure.string/includes? (str (.getMessage e)) "SSL peer shut down incorrectly")
+        (log/warn "agent force shutdown due to connection issues")
+        (System/exit 1)))
+    (catch Exception e
+      (log/error (format "failed to poll tasks with error: %s" e))
+      (sentry-logger {:message "failed to poll tasks" :throwable e}))))
 
 (defn poll [backoff-http-poll-ms]
   (log/info "Starting task poller...")
-  (async/go-loop []
-    (Thread/sleep backoff-http-poll-ms)
+  (loop []
     (poll-tasks)
+    (Thread/sleep backoff-http-poll-ms)
     (recur)))

--- a/src/agent/http_poller.clj
+++ b/src/agent/http_poller.clj
@@ -6,8 +6,7 @@
             [agent.agent :as agent]
             [runtime.data :refer [runtime-data]]
             [camel-snake-kebab.extras :as cske]
-            [camel-snake-kebab.core :as csk]
-            [clojure.core.async :as async]))
+            [camel-snake-kebab.core :as csk]))
 
 (def poll-params
   (conj {:runner_provider "runops" :status "ready"}

--- a/src/runtime/data.clj
+++ b/src/runtime/data.clj
@@ -34,12 +34,12 @@
         hostname (get-hostname)
         tags (:tags envs)
         jwk-verify (not (clojure.string/blank? jwk-url))
-        jwk-url (if (clojure.string/blank? jwk-url) "runops:null" jwk-url)
-        machine-id (if (clojure.string/blank? machine-id) "runops:null" machine-id)
-        distro-name (if (clojure.string/blank? distro-name) "runops:null" distro-name)
-        kernel-version (if (clojure.string/blank? kernel-version) "runops:null" kernel-version)
-        hostname (if (clojure.string/blank? hostname) "runops:null" hostname)
-        tags (if (clojure.string/blank? tags) "runops:null" tags)]
+        jwk-url (if (clojure.string/blank? jwk-url) "" jwk-url)
+        machine-id (if (clojure.string/blank? machine-id) "" machine-id)
+        distro-name (if (clojure.string/blank? distro-name) "" distro-name)
+        kernel-version (if (clojure.string/blank? kernel-version) "" kernel-version)
+        hostname (if (clojure.string/blank? hostname) "" hostname)
+        tags (if (clojure.string/blank? tags) "" tags)]
     {:machine-id machine-id
      :distro distro-name
      :kernel-version kernel-version

--- a/src/runtime/init.clj
+++ b/src/runtime/init.clj
@@ -29,8 +29,8 @@
            send-event-timeout-ms
            nil)
     (catch Exception e
-      (log/error (format "Failed to fetch runtime config, backing off for [%s] second(s). ex=%s"
-                         (backoff/ms->sec send-event-timeout-ms) e))
+      (log/error e (format "Failed to fetch runtime config, backing off for [%s] second(s)"
+                           (backoff/ms->sec send-event-timeout-ms)))
       (Thread/sleep send-event-timeout-ms)
       nil)))
 

--- a/src/tracer/honeycomb.clj
+++ b/src/tracer/honeycomb.clj
@@ -126,6 +126,7 @@
   (try
     (traced-fn task)
     (catch Exception e
+      (log/error e "failed processing task")
       [nil (format "failed in processing, err=%s" (.getMessage e))])))
 
 (defn- safe-end [span]


### PR DESCRIPTION
- Update gRPC clients libs
- Remove async/go calls over async/thread to avoid depleting the fixed pool of go block threads
- Make null runtime data as empty string instead of using runops:null string
- Add resilience to webhook calls over gRPC
- Allows a max of 30 tasks to run in parallel per agent