### PR TITLE
Fix secret manager bug when initializing it without valid credentials

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [clj-kondo "2021.08.06"]
                  [mount "0.1.16"]
                  [clj-http "3.12.3"]
-                 [software.amazon.awssdk/secretsmanager "2.16.69"]
+                 [software.amazon.awssdk/secretsmanager "2.17.102"]
                  [camel-snake-kebab "0.4.2"]
                  [de.ubercode.clostache/clostache "1.4.0"]
                  [buddy "2.0.0"]]

--- a/src/agent/clients.clj
+++ b/src/agent/clients.clj
@@ -101,11 +101,11 @@
     (when-not disable-aws-secret-manager
       (log/info "Initializing AWS Secret Manager ...")
       (SecretsManagerClient/create))
-    (catch Exception e
+    (catch Throwable e
       (log/warn (format "Could not start AWS client with error: %s" e)))))
 
 (defn aws-client-stop []
   (try
     (when-not disable-aws-secret-manager (.close aws-client))
-    (catch Exception e
+    (catch Throwable e
       (log/warn (format "Could not close AWS client with error: %s" e)))))

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -2,7 +2,8 @@
   (:require [agent.clients :as _]
             [version.version :refer [git-revision]]
             [logger.timbre :as log]
-            [taoensso.timbre :refer [merge-config! set-config!]]
+            [taoensso.timbre :refer [merge-config! set-config!
+                                     handle-uncaught-jvm-exceptions!]]
             [logger.timbre-json :as timbre-json]
             [taoensso.timbre.appenders.core :as appenders]
             [agent.http-poller :as http]
@@ -19,6 +20,7 @@
 
 ;; comment it for non-json logging
 (merge-config! {:output-fn timbre-json/output-fn})
+(handle-uncaught-jvm-exceptions!)
 
 (defn -main [& _]
   (log/info {:git-revision git-revision} "Starting agent")

--- a/src/logger/timbre_json.clj
+++ b/src/logger/timbre_json.clj
@@ -1,7 +1,10 @@
 (ns logger.timbre-json
   (:require [cheshire.core :as json]
-            [taoensso.timbre :as timbre]
             [version.version :refer [app-version]]))
+
+(defn get-stacktrace [err]
+  (try (map str (.getStackTrace err))
+       (catch Exception _ nil)))
 
 (defn output-fn [data]
   (let [{:keys [level ?err #_vargs msg_ ?ns-str ?file
@@ -18,5 +21,5 @@
                             (when (map? (:context data))
                               {:context (:context data)})
                             {:msg (force msg_)})
-                      ?err (assoc :err (timbre/stacktrace ?err {:stacktrace-fonts {}})))]
+                      ?err (assoc :err (get-stacktrace ?err)))]
     (json/generate-string output-data)))


### PR DESCRIPTION
- Add func to handle uncaught jvm exceptions with timbre
- Catch Throwable instead of Exception to avoid uncaught exceptions when initializing secret manager
- Bump version of `software.amazon.awssdk/secretsmanager`