### PR TITLE
Make output-fn keys as PersistentArrayMap to preserve order on decoding

### DIFF
--- a/src/logger/timbre.clj
+++ b/src/logger/timbre.clj
@@ -12,27 +12,19 @@
 (defn warn
   ([msg] (log/warn msg))
   ([context-or-trowable msg]
-   (when (instance? java.lang.Exception context-or-trowable)
-     (log/with-context
-       {:err context-or-trowable}
-       (log/warn msg)))
+   (when (instance? java.lang.Throwable context-or-trowable)
+     (log/warn context-or-trowable msg))
    (when (map? context-or-trowable)
      (log/with-context context-or-trowable (log/warn msg))))
   ([ex context msg]
-   (log/with-context
-     (assoc context :err ex)
-     (log/warn msg))))
+   (log/with-context context (log/warn ex msg))))
 
 (defn error
   ([msg] (log/error msg))
   ([context-or-trowable msg]
-   (when (instance? java.lang.Exception context-or-trowable)
-     (log/with-context
-       {:err context-or-trowable}
-       (log/error msg)))
+   (when (instance? java.lang.Throwable context-or-trowable)
+     (log/error context-or-trowable msg))
    (when (map? context-or-trowable)
      (log/with-context context-or-trowable (log/error msg))))
   ([ex context msg]
-   (log/with-context
-     (assoc context :err ex)
-     (log/error msg))))
+   (log/with-context context (log/error ex msg))))


### PR DESCRIPTION
- Fix log warn and error funcs