### PR TITLE
Fix webhook calls issues failing to report status of tasks

### DIFF
--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -6,7 +6,6 @@
             [clojure.java.io :refer [delete-file]]
             [agent.clients :as clients]
             [agent.secrets :as secrets]
-            [io.grpc.Agent.client :as grpc-client]
             [cognitect.aws.client.api :as aws]
             [cognitect.aws.credentials :as credentials]
             [clj-http.client :as http-client]


### PR DESCRIPTION
- Add webhook resilience over http poller
- Removed gRPC webhook due to bug on processing unary requests
  - Fix repeated slack messages when sending webhooks over gRPC