### PR TITLE
Add GCP DLP to agent

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/core.async "1.5.644"]
                  [org.clojure/data.json "1.0.0"]
+                 [buddy "2.0.0"]
                  [buddy/buddy-core "1.10.1"]
                  [buddy/buddy-sign "3.4.1"]
 
@@ -35,13 +36,16 @@
                  [com.cognitect.aws/api "0.8.524"]
                  [com.cognitect.aws/endpoints "1.1.12.69"]
                  [com.cognitect.aws/ecs "813.2.972.0"]
+
+                 ;; gcp
+                 [com.google.cloud/google-cloud-dlp "3.1.0"]
+
                  [clj-kondo "2021.08.06"]
                  [mount "0.1.16"]
                  [clj-http "3.12.3"]
                  [software.amazon.awssdk/secretsmanager "2.17.102"]
                  [camel-snake-kebab "0.4.2"]
-                 [de.ubercode.clostache/clostache "1.4.0"]
-                 [buddy "2.0.0"]]
+                 [de.ubercode.clostache/clostache "1.4.0"]]
   :plugins [[lein-bump-version "0.1.6"]]
   :source-paths ["src" "test"]
   :main ^:skip-aot agent.core

--- a/resources/agent.proto
+++ b/resources/agent.proto
@@ -29,6 +29,8 @@ message RuntimeConfigurationResponse {
   string sentry_dsn = 5;
   string sentry_env = 6;
   ConnectionConfig connection_config = 7;
+  string dlp_auth_b64 = 8;
+  repeated string dlp_fields = 9;
 }
 
 message TaskResponse {
@@ -50,6 +52,7 @@ message LogsRequest {
   int32 id = 1;
   string status = 2;
   string logs = 3;
+  bool redacted = 4;
 }
 
 message LogsResponse {

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -10,7 +10,8 @@
             [agent.grpc-subscriber :as grpc]
             [backoff.time :as backoff]
             [runtime.init :as init]
-            [mount.core :as mount])
+            [mount.core :as mount]
+            [dlp.gcp :as dlp])
   (:gen-class))
 
 (def tags (System/getenv "TAGS"))
@@ -32,26 +33,40 @@
         backoff-http-poll (get-in runtime-config [:connection-config :backoff-http-poll])
         grpc-channel-timeout (backoff/parse-default grpc-channel-timeout (backoff/min->ms 5))
         backoff-grpc-connect-subscribe (backoff/parse-default backoff-grpc-connect-subscribe (backoff/sec->ms 5))
-        backoff-http-poll (backoff/parse-default backoff-http-poll (backoff/sec->ms 15))]
-    (log/info (format "Agent config id=[%s] loaded with success. Backoff grpc-channel-timeout=[%s] grpc-conn-subscribe=[%s] http-poll=[%s] "
+        backoff-http-poll (backoff/parse-default backoff-http-poll (backoff/sec->ms 15))
+        dlp-fields (:dlp-fields runtime-config)
+        dlp-fields (if (> (count dlp-fields) 0) dlp-fields dlp/default-info-types)]
+    (log/info (format (str "Agent config id=[%s] loaded with success. Backoff grpc-channel-timeout=[%s]"
+                           " grpc-conn-subscribe=[%s] http-poll=[%s] total-dlp-fields=[%s]")
                       (:id runtime-config)
                       grpc-channel-timeout
                       backoff-grpc-connect-subscribe
-                      backoff-http-poll))
-    (future (grpc/listen-subscription well-known-jwks grpc-channel-timeout backoff-grpc-connect-subscribe))
-    (http/poll backoff-http-poll)))
+                      backoff-http-poll
+                      (count (:dlp-fields runtime-config))))
+    (future (grpc/listen-subscription {:well-known-jwks well-known-jwks
+                                       :dlp-fields dlp-fields
+                                       :channel-timeout-ms grpc-channel-timeout
+                                       :backoff-subscribe-ms backoff-grpc-connect-subscribe}))
+    (http/poll dlp-fields backoff-http-poll)))
 
 (defn run-grpc-dev []
-  (log/info "Running in gRPC mode - development mode")
   (let [runtime-config (init/fetch-agent-config)
         _ (-> (mount/with-args runtime-config) mount/start)
         well-known-jwks (init/fetch-jwks-pubkeys)
         grpc-channel-timeout (get-in runtime-config [:connection-config :grpc-connect-channel-timeout])
         backoff-grpc-connect-subscribe (get-in runtime-config [:connection-config :backoff-grpc-connect-subscribe])
         grpc-channel-timeout (backoff/parse-default grpc-channel-timeout (backoff/min->ms 5))
-        backoff-grpc-connect-subscribe (backoff/parse-default backoff-grpc-connect-subscribe (backoff/sec->ms 5))]
-    (log/info (format "Agent config id=[%s] loaded with success. Backoff grpc-channel-timeout=[%s] grpc-conn-subscribe=[%s] "
+        backoff-grpc-connect-subscribe (backoff/parse-default backoff-grpc-connect-subscribe (backoff/sec->ms 5))
+        dlp-fields (:dlp-fields runtime-config)
+        dlp-fields (if (> (count dlp-fields) 0) dlp-fields dlp/default-info-types)]
+    (log/info (format (str "Agent config id=[%s] loaded with success. Backoff grpc-channel-timeout=[%s]"
+                           " grpc-conn-subscribe=[%s] total-dlp-fields=[%s]")
                       (:id runtime-config)
                       grpc-channel-timeout
-                      backoff-grpc-connect-subscribe))
-    (grpc/listen-subscription well-known-jwks grpc-channel-timeout backoff-grpc-connect-subscribe)))
+                      backoff-grpc-connect-subscribe
+                      (count (:dlp-fields runtime-config))))
+    (grpc/listen-subscription {:well-known-jwks well-known-jwks
+                               :dlp-fields dlp-fields
+                               :channel-timeout-ms grpc-channel-timeout
+                               :backoff-subscribe-ms backoff-grpc-connect-subscribe})))
+

--- a/src/dlp/gcp.clj
+++ b/src/dlp/gcp.clj
@@ -1,0 +1,239 @@
+(ns dlp.gcp
+  (:require [logger.timbre :as log]
+            [clojure.java.io :refer [input-stream]]
+            [mount.core :refer [defstate] :as mount])
+  (:import com.google.cloud.dlp.v2.DlpServiceClient
+           com.google.cloud.dlp.v2.DlpServiceSettings
+           com.google.api.gax.core.FixedCredentialsProvider
+           com.google.privacy.dlp.v2.ByteContentItem
+           com.google.privacy.dlp.v2.ByteContentItem$BytesType
+           com.google.privacy.dlp.v2.ContentItem
+           com.google.privacy.dlp.v2.InfoType
+           com.google.privacy.dlp.v2.InspectConfig
+           com.google.privacy.dlp.v2.InspectContentRequest
+           com.google.privacy.dlp.v2.LocationName
+           com.google.privacy.dlp.v2.Likelihood
+           com.google.protobuf.ByteString
+           com.google.auth.oauth2.GoogleCredentials))
+
+(def numbers-to-mask 5)
+(def max-info-types 35)
+;; this values needs to be low to avoid the max limit of findings (3000) per chunk
+;; thus we send chunks of 0.0625 Megabytes
+;; https://cloud.google.com/dlp/limits#content-limits
+(def max-chunk-size 62500)
+(def default-info-types
+  ["PHONE_NUMBER"
+   "AGE"
+   "CREDIT_CARD_NUMBER"
+   "CREDIT_CARD_TRACK_NUMBER"
+   "DATE_OF_BIRTH"
+   "EMAIL_ADDRESS"
+   "ETHNIC_GROUP"
+   "GENDER"
+   "IBAN_CODE"
+   "HTTP_COOKIE"
+   "ICD9_CODE"
+   "ICD10_CODE"
+   "IMEI_HARDWARE_ID"
+   "IP_ADDRESS"
+   "STORAGE_SIGNED_URL"
+   "URL"
+   "VEHICLE_IDENTIFICATION_NUMBER"
+   "BRAZIL_CPF_NUMBER"
+   "AMERICAN_BANKERS_CUSIP_ID"
+   "FDA_CODE"
+   "US_ADOPTION_TAXPAYER_IDENTIFICATION_NUMBER"
+   "US_BANK_ROUTING_MICR"
+   "US_DEA_NUMBER"
+   "US_DRIVERS_LICENSE_NUMBER"
+   "US_EMPLOYER_IDENTIFICATION_NUMBER"
+   "US_HEALTHCARE_NPI"
+   "US_INDIVIDUAL_TAXPAYER_IDENTIFICATION_NUMBER"
+   "US_PASSPORT"
+   "US_PREPARER_TAXPAYER_IDENTIFICATION_NUMBER"
+   "US_SOCIAL_SECURITY_NUMBER"
+   "US_TOLLFREE_PHONE_NUMBER"
+   "US_VEHICLE_IDENTIFICATION_NUMBER"])
+
+(defn- parse-service-account [serv-account-enc]
+  (log/info "Initializing Data Loss Prevention client ...")
+  (try
+    (let [goog-cred (GoogleCredentials/fromStream
+                     (input-stream (-> (java.util.Base64/getDecoder)
+                                       (.decode serv-account-enc))))
+          project-id (.getProjectId goog-cred)]
+      [project-id goog-cred])
+    (catch Exception e
+      (log/warn e "failed to start Data Loss Prevention client"))))
+
+(defstate ^:private google-credentials
+  :start (parse-service-account (:dlp-auth-b64 (mount/args)))
+  :stop nil)
+
+(defn- finding->map [^com.google.privacy.dlp.v2.Finding f]
+  {:finding-id (.getFindingId f)
+   :info-type (-> f (.getInfoType) (.getName))
+  ;;  :quote (.getQuote f)
+   :likelihood (.toString (.getLikelihood f))
+   :start (-> f (.getLocation) (.getByteRange) (.getStart))
+   :end (-> f (.getLocation) (.getByteRange) (.getEnd))})
+
+(defn findings-metrics
+  "Given a list of findings-list and count of total-chunks, return
+   a map containing metrics"
+  [findings-list total-chunks]
+  (let [total-findings (count (into [] cat findings-list))
+        findings-chunks (count findings-list)]
+    {:agent.dlp.total_findings total-findings
+     :agent.dlp.total_findings_chunks findings-chunks
+     :agent.dlp.total_chunks total-chunks
+     :agent.dlp.estimated_findings_per_chunk (int (/ total-findings (max findings-chunks 1)))}))
+
+(defn- build-info-types
+  ([info-types]
+   (let [arr (java.util.ArrayList.)
+         _ (doall (map #(.add arr (-> (InfoType/newBuilder)
+                                      (.setName %)
+                                      (.build))) info-types))] arr
+        arr))
+  ([] (build-info-types default-info-types)))
+
+(defn bytes->chunks
+  "break down bytes or string to a list of byte array chunks"
+  ([bytes-or-str]
+   (bytes->chunks bytes-or-str max-chunk-size))
+  ([bytes-or-str chunk-limit]
+   (let [bytes-vec (cond
+                     (string? bytes-or-str) (vec (.getBytes bytes-or-str))
+                     (bytes? bytes-or-str) (vec bytes-or-str)
+                     :else (throw (IllegalArgumentException. "wrong input type for bytes-or-str param")))
+         input-length (count bytes-or-str)]
+     (loop [chunk-start 0
+            chunk-end chunk-limit
+            result []]
+       (let [chunk-end (min chunk-end input-length)
+             chunk-result (byte-array (subvec bytes-vec chunk-start chunk-end))
+             chunk-result (conj result chunk-result)]
+         (if (= chunk-end input-length)
+           chunk-result
+           (recur chunk-end
+                  (min (+ chunk-end chunk-limit) input-length)
+                  chunk-result)))))))
+
+(defn process-chunks
+  "It will break chunks by groups and apply in parallel the f function in a future, 
+   blocking until the chunk group results are returned iterating throughout
+   chunks in the list. It returns the results in a vector."
+  ([f chunk-list]
+   (process-chunks
+    (+ 2 (.. Runtime getRuntime availableProcessors))
+    15000
+    f chunk-list))
+  ([n timeout-ms f chunk-list]
+   (loop [chunks chunk-list
+          findings-results []]
+     (if (empty? chunks)
+       findings-results
+       (let [chunk-group (take n chunks)
+             findings (into [] (doall (map #(deref % timeout-ms nil)
+                                           (pmap #(future (f %))
+                                                 chunk-group))))
+             findings-results (into [] cat [findings-results findings])]
+         (recur (drop n chunks)
+                findings-results))))))
+
+(defn redact-by-findings
+  "Redact content base on a vector of com.google.privacy.dlp.v2.Finding,
+   the findings->map structure must be sorted increasingly by :start"
+  [bytes-or-str findings-list]
+  (let [input-bytes
+        (cond
+          (string? bytes-or-str) (vec (.getBytes bytes-or-str))
+          (bytes? bytes-or-str) (vec bytes-or-str)
+          :else (throw (IllegalArgumentException. "wrong input type for bytes-or-str param")))]
+    (loop [index 0
+           flist findings-list
+           redact-result []]
+      (if (empty? flist)
+        (byte-array
+         (concat redact-result
+                 (subvec input-bytes (get (last findings-list) :end 0) (count input-bytes))))
+        (let [finding (first flist)
+              ;; select a chunk until the occurence of a finding
+              previous-finding (nth findings-list (max 0 (- index 1)))
+              chunk-idx-start (if (= (:start previous-finding) (:start finding)) 0
+                                  (:end previous-finding))
+              chunk-idx-end (:start finding)
+              chunk (subvec input-bytes chunk-idx-start chunk-idx-end)
+              ;; select the chunk to be replaced and concat with the character to mask it
+              chunk-to-replace (subvec input-bytes (:start finding) (:end finding))
+              chunk-to-replace-max (count chunk-to-replace)
+              chunk-to-replace (concat (.getBytes (clojure.string/join (repeat numbers-to-mask "*")))
+                                       ;;  TODO: change to max instead of using if here!
+                                       (subvec chunk-to-replace
+                                               (if (< chunk-to-replace-max numbers-to-mask)
+                                                 chunk-to-replace-max
+                                                 numbers-to-mask)
+                                               chunk-to-replace-max))]
+          (recur (inc index)
+                 (rest flist)
+                 (into [] cat [redact-result chunk chunk-to-replace])))))))
+
+(defn inspect-content
+  "Inspect strings for sensitive data, returning a list of map
+   extracted from a com.google.privacy.dlp.v2.Finding object, by providing:
+   * text-input as string
+   * info-type as a vector of info types strings, if it's not set it will use default ones
+   inspired in this example: https://cloud.google.com/dlp/docs/inspecting-text"
+  ([text-input]
+   (inspect-content text-input default-info-types))
+  ([text-input info-types]
+   (when (> (count info-types) max-info-types)
+     (throw (IllegalArgumentException.
+             (format "Max info-types per request reached %s/%s" (count info-types) max-info-types))))
+   (let [byte-item (-> (ByteContentItem/newBuilder)
+                       (.setType (ByteContentItem$BytesType/TEXT_UTF8))
+                       (.setData (ByteString/copyFromUtf8 (String. text-input)))
+                       (.build))
+         item (-> (ContentItem/newBuilder)
+                  (.setByteItem byte-item)
+                  (.build))
+         config (-> (InspectConfig/newBuilder)
+                    (.addAllInfoTypes (build-info-types info-types))
+                    (.setMinLikelihood (Likelihood/POSSIBLE)) ; https://cloud.google.com/dlp/docs/likelihood
+                    (.setIncludeQuote true)
+                    (.build))
+         [project-id goog-cred] google-credentials
+         _ (when (nil? goog-cred) (throw (IllegalStateException.
+                                          "failed to obtain GCP credentials")))
+         req (-> (InspectContentRequest/newBuilder)
+                 (.setParent (.toString (LocationName/of project-id "global")))
+                 (.setItem item)
+                 (.setInspectConfig config)
+                 (.build))
+         client (DlpServiceClient/create
+                 (-> (DlpServiceSettings/newBuilder)
+                     (.setCredentialsProvider (FixedCredentialsProvider/create goog-cred))
+                     (.build)))
+         content (-> client (.inspectContent req))
+         findings (-> content
+                      (.getResult)
+                      (.getFindingsList))
+         _ (.close client)]
+     (into [] (doall (map finding->map findings))))))
+
+(comment
+  (let [gcp-base64-service-account "<json-base64-service-account-credentials>"
+        _ (-> (mount/with-args {:dlp-auth-b64 gcp-base64-service-account}) mount/start)
+        text-input (str "My name is Gary Oldman and my email is gary.duck@example.com and my phone number is +5511959606814, my ip address "
+                        "is 200.20.10.100, my website is runops.io my cpf is 46251484136 my gender is male and i have 25 years old "
+                        "and my birthday is 04 of June!")
+        chunk-list (bytes->chunks text-input)
+        sorted-findings-list (process-chunks
+                              (fn [chunk]
+                                (into [] (sort #(compare (:start %1) (:start %2))
+                                               (inspect-content chunk))))
+                              chunk-list)
+        result (pmap #(redact-by-findings %1 %2) chunk-list sorted-findings-list)]
+    (String. (byte-array (into [] cat result)))))

--- a/src/io/grpc.cljc
+++ b/src/io/grpc.cljc
@@ -107,29 +107,33 @@
 ;-----------------------------------------------------------------------------
 ; RuntimeConfigurationResponse
 ;-----------------------------------------------------------------------------
-(defrecord RuntimeConfigurationResponse-record [id org hc-dataset hc-api-key sentry-dsn sentry-env connection-config]
+(defrecord RuntimeConfigurationResponse-record [hc-dataset org hc-api-key id sentry-env sentry-dsn dlp-auth-b64 dlp-fields connection-config]
   pb/Writer
   (serialize [this os]
-    (serdes.core/write-String 1  {:optimize true} (:id this) os)
-    (serdes.core/write-String 2  {:optimize true} (:org this) os)
     (serdes.core/write-String 3  {:optimize true} (:hc-dataset this) os)
+    (serdes.core/write-String 2  {:optimize true} (:org this) os)
     (serdes.core/write-String 4  {:optimize true} (:hc-api-key this) os)
-    (serdes.core/write-String 5  {:optimize true} (:sentry-dsn this) os)
+    (serdes.core/write-String 1  {:optimize true} (:id this) os)
     (serdes.core/write-String 6  {:optimize true} (:sentry-env this) os)
+    (serdes.core/write-String 5  {:optimize true} (:sentry-dsn this) os)
+    (serdes.core/write-String 8  {:optimize true} (:dlp-auth-b64 this) os)
+    (serdes.complex/write-repeated serdes.core/write-String 9 (:dlp-fields this) os)
     (serdes.core/write-embedded 7 (:connection-config this) os))
   pb/TypeReflection
   (gettype [this]
     "io.grpc.RuntimeConfigurationResponse"))
 
-(s/def :io.grpc.RuntimeConfigurationResponse/id string?)
-(s/def :io.grpc.RuntimeConfigurationResponse/org string?)
 (s/def :io.grpc.RuntimeConfigurationResponse/hc-dataset string?)
+(s/def :io.grpc.RuntimeConfigurationResponse/org string?)
 (s/def :io.grpc.RuntimeConfigurationResponse/hc-api-key string?)
-(s/def :io.grpc.RuntimeConfigurationResponse/sentry-dsn string?)
+(s/def :io.grpc.RuntimeConfigurationResponse/id string?)
 (s/def :io.grpc.RuntimeConfigurationResponse/sentry-env string?)
+(s/def :io.grpc.RuntimeConfigurationResponse/sentry-dsn string?)
+(s/def :io.grpc.RuntimeConfigurationResponse/dlp-auth-b64 string?)
+(s/def :io.grpc.RuntimeConfigurationResponse/dlp-fields (s/every string?))
 
-(s/def ::RuntimeConfigurationResponse-spec (s/keys :opt-un [:io.grpc.RuntimeConfigurationResponse/id :io.grpc.RuntimeConfigurationResponse/org :io.grpc.RuntimeConfigurationResponse/hc-dataset :io.grpc.RuntimeConfigurationResponse/hc-api-key :io.grpc.RuntimeConfigurationResponse/sentry-dsn :io.grpc.RuntimeConfigurationResponse/sentry-env ]))
-(def RuntimeConfigurationResponse-defaults {:id "" :org "" :hc-dataset "" :hc-api-key "" :sentry-dsn "" :sentry-env "" })
+(s/def ::RuntimeConfigurationResponse-spec (s/keys :opt-un [:io.grpc.RuntimeConfigurationResponse/hc-dataset :io.grpc.RuntimeConfigurationResponse/org :io.grpc.RuntimeConfigurationResponse/hc-api-key :io.grpc.RuntimeConfigurationResponse/id :io.grpc.RuntimeConfigurationResponse/sentry-env :io.grpc.RuntimeConfigurationResponse/sentry-dsn :io.grpc.RuntimeConfigurationResponse/dlp-auth-b64 :io.grpc.RuntimeConfigurationResponse/dlp-fields ]))
+(def RuntimeConfigurationResponse-defaults {:hc-dataset "" :org "" :hc-api-key "" :id "" :sentry-env "" :sentry-dsn "" :dlp-auth-b64 "" :dlp-fields [] })
 
 (defn cis->RuntimeConfigurationResponse
   "CodedInputStream to RuntimeConfigurationResponse"
@@ -137,12 +141,14 @@
   (->> (tag-map RuntimeConfigurationResponse-defaults
          (fn [tag index]
              (case index
-               1 [:id (serdes.core/cis->String is)]
-               2 [:org (serdes.core/cis->String is)]
                3 [:hc-dataset (serdes.core/cis->String is)]
+               2 [:org (serdes.core/cis->String is)]
                4 [:hc-api-key (serdes.core/cis->String is)]
-               5 [:sentry-dsn (serdes.core/cis->String is)]
+               1 [:id (serdes.core/cis->String is)]
                6 [:sentry-env (serdes.core/cis->String is)]
+               5 [:sentry-dsn (serdes.core/cis->String is)]
+               8 [:dlp-auth-b64 (serdes.core/cis->String is)]
+               9 [:dlp-fields (serdes.complex/cis->repeated serdes.core/cis->String is)]
                7 [:connection-config (ecis->ConnectionConfig is)]
 
                [index (serdes.core/cis->undefined tag is)]))
@@ -285,12 +291,13 @@
 ;-----------------------------------------------------------------------------
 ; LogsRequest
 ;-----------------------------------------------------------------------------
-(defrecord LogsRequest-record [id status logs]
+(defrecord LogsRequest-record [id status logs redacted]
   pb/Writer
   (serialize [this os]
     (serdes.core/write-Int32 1  {:optimize true} (:id this) os)
     (serdes.core/write-String 2  {:optimize true} (:status this) os)
-    (serdes.core/write-String 3  {:optimize true} (:logs this) os))
+    (serdes.core/write-String 3  {:optimize true} (:logs this) os)
+    (serdes.core/write-Bool 4  {:optimize true} (:redacted this) os))
   pb/TypeReflection
   (gettype [this]
     "io.grpc.LogsRequest"))
@@ -298,8 +305,9 @@
 (s/def :io.grpc.LogsRequest/id int?)
 (s/def :io.grpc.LogsRequest/status string?)
 (s/def :io.grpc.LogsRequest/logs string?)
-(s/def ::LogsRequest-spec (s/keys :opt-un [:io.grpc.LogsRequest/id :io.grpc.LogsRequest/status :io.grpc.LogsRequest/logs ]))
-(def LogsRequest-defaults {:id 0 :status "" :logs "" })
+(s/def :io.grpc.LogsRequest/redacted boolean?)
+(s/def ::LogsRequest-spec (s/keys :opt-un [:io.grpc.LogsRequest/id :io.grpc.LogsRequest/status :io.grpc.LogsRequest/logs :io.grpc.LogsRequest/redacted ]))
+(def LogsRequest-defaults {:id 0 :status "" :logs "" :redacted false })
 
 (defn cis->LogsRequest
   "CodedInputStream to LogsRequest"
@@ -310,6 +318,7 @@
                1 [:id (serdes.core/cis->Int32 is)]
                2 [:status (serdes.core/cis->String is)]
                3 [:logs (serdes.core/cis->String is)]
+               4 [:redacted (serdes.core/cis->Bool is)]
 
                [index (serdes.core/cis->undefined tag is)]))
          is)

--- a/src/tracer/honeycomb.clj
+++ b/src/tracer/honeycomb.clj
@@ -92,8 +92,12 @@
          task-output (cond
                        (= (:status task-err) "failure") (:logs task-err)
                        (= (string? task-err) task-err)
-                       "")]
+                       "")
+         tracing-context (merge (:tracing-context (first fn-result))
+                                (:tracing-context task-err))]
      (set-span-attribute parent-span "error" task-output)
+     (when (not (nil? tracing-context))
+       (set-span-attributes parent-span tracing-context))
      (when (some? task-err)
        ((with-tracing-end) task))
      (safe-end parent-span)
@@ -105,8 +109,9 @@
                         (.startSpan))
                     (merge map-attrs
                            {:task-id (:id task)
-                            :agent-version app-version
-                            :agent-revision git-revision}))
+                            :agent.task_id (:id task)
+                            :agent.version app-version
+                            :agent.revision git-revision}))
          fn-result (call-traced-fn traced-fn (assoc task :tracing-spans
                                                     {root-key root-span}))
          task-err (second fn-result)
@@ -116,8 +121,12 @@
          task-output (cond
                        (= (:status task-err) "failure") (:logs task-err)
                        (= (string? task-err) task-err)
-                       "")]
+                       "")
+         tracing-context (merge (:tracing-context (first fn-result))
+                                (:tracing-context task-err))]
      (set-span-attribute root-span "error" task-output)
+     (when (not (nil? tracing-context))
+       (set-span-attributes root-span tracing-context))
      (when (some? task-err)
        ((with-tracing-end) task))
      fn-result)))

--- a/test/dlp/gcp_test.clj
+++ b/test/dlp/gcp_test.clj
@@ -1,0 +1,103 @@
+(ns dlp.gcp-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [dlp.gcp :as dlp]))
+
+(def input-text (str "My name is Gary Oldman and my email is gary.duck@example.com "
+                     "and my phone number is +5511959606814, my ip address is 200.20.10.100, "
+                     "my website is runops.io my cpf is 46251484136 my gender is male "
+                     "and i have 25 years old my birthday is 04 of June!"))
+(def redacted-input (str "My name is Gary Oldman and my email is *****duck@example.com "
+                         "and my phone number is *****959606814, my ip address is *****0.10.100, "
+                         "my website is *****s.io my cpf is *****484136 my gender is ***** "
+                         "and i have *****ars old my birthday is ***** June!"))
+
+(def findings-list [{:finding-id "2022-01-12T16:04:53.402171Z2228834116584927040"
+                     :info-type "EMAIL_ADDRESS"
+                     :quote "gary.duck@example.com"
+                     :likelihood "VERY_LIKELY"
+                     :start 39
+                     :end 60}
+                    {:finding-id "2022-01-12T16:04:53.402174Z8072478956957853268"
+                     :info-type "PHONE_NUMBER"
+                     :quote "+5511959606814"
+                     :likelihood "VERY_LIKELY"
+                     :start 84
+                     :end 98}
+                    {:finding-id "2022-01-12T16:04:53.402140Z5591059405735705230"
+                     :info-type "IP_ADDRESS"
+                     :quote "200.20.10.100"
+                     :likelihood "LIKELY"
+                     :start 117
+                     :end 130}
+                    {:finding-id "2022-01-12T16:04:53.402166Z7134793372037236706"
+                     :info-type "URL"
+                     :quote "runops.io"
+                     :likelihood "POSSIBLE"
+                     :start 146
+                     :end 155}
+                    {:finding-id "2022-01-12T16:04:53.402177Z3345376263066899337"
+                     :info-type "BRAZIL_CPF_NUMBER"
+                     :quote "46251484136"
+                     :likelihood "POSSIBLE"
+                     :start 166
+                     :end 177}
+                    {:finding-id "2022-01-12T16:04:53.402180Z3370601685672683044"
+                     :info-type "GENDER"
+                     :quote "male"
+                     :likelihood "LIKELY"
+                     :start 191
+                     :end 195}
+                    {:finding-id "2022-01-12T16:04:53.402183Z1008799718046668068"
+                     :info-type "AGE"
+                     :quote "25 years old"
+                     :likelihood "VERY_LIKELY"
+                     :start 207
+                     :end 219}
+                    {:finding-id "2022-01-12T16:04:53.402185Z2889842100858079150"
+                     :info-type "DATE_OF_BIRTH"
+                     :quote "04 of June"
+                     :likelihood "VERY_LIKELY"
+                     :start 235
+                     :end 245}])
+
+(deftest bytes->chunks
+  (testing "must break a text into multiple chunks maintaining the order"
+    (let [chunks-of 10
+          chunk-size (int (Math/ceil (/ (count input-text) 10)))
+          chunk-list (dlp/bytes->chunks input-text chunks-of)]
+      (is (= (count chunk-list) chunk-size))
+      (is (= input-text (String. (byte-array (into [] cat chunk-list)))))))
+  (testing "must throw exception when the input is neither string or bytes"
+    (is (thrown? Exception (dlp/bytes->chunks 123)))))
+
+(deftest process-chunks
+  (testing "must process a group of chunks blocking until finish, then move on to the next group"
+    (let [chunks-of 2
+          chunk-sleep 500
+          chunk-list ["a" "chunk" "list" "of" "words" "!!!"]
+          f (fn [chunk] (Thread/sleep chunk-sleep) chunk)
+          p-timeout (future (dlp/process-chunks chunks-of 15000 f chunk-list))
+          p-ok (future (dlp/process-chunks chunks-of 15000 f chunk-list))]
+      (is (= (deref p-timeout 1400 nil) nil))
+      (is (= (deref p-ok 1600 nil) chunk-list))))
+  (testing "must process a group of chunks and return the result sorted"
+    (let [findings [{:start 32} {:start 12}]
+          f (fn [_] (into [] (sort #(compare (:start %1) (:start %2)) findings)))
+          [start-first start-second] (first (dlp/process-chunks f ["a" "chunk" "list"]))]
+      (is (= (:start start-first) 12)
+          (= (:start start-second) 32))))
+  (testing "must timeout and return nil"
+    (let [f (fn [chunk] (Thread/sleep 500) chunk)
+          res (dlp/process-chunks 2 100 f ["a" "chunk" "list"])]
+      (is (= res [nil nil nil])))))
+
+(deftest redact-by-findings
+  (testing "must redact all content based on the findings list"
+    (let [res (dlp/redact-by-findings input-text findings-list)]
+      (is (= (String. res) redacted-input))))
+  (testing "must throw exception when the input is neither string or bytes"
+    (is (thrown? Exception (dlp/redact-by-findings 123 findings-list))))
+  (testing "must throw index out of bounds exception when the findings list is unsorted"
+    (is (thrown? IndexOutOfBoundsException
+                 (dlp/redact-by-findings input-text [{:start 30 :end 40}
+                                                     {:start 15 :end 20}])))))


### PR DESCRIPTION
Add GCP DLP to agent which redact the content by findings up to 1MB, in case of errors or above that limit it will be processed by the server.

- Load dlp-fields on a per org base configuration
- Improve honeycomb instrumentation
  - Add tracing metrics to webhook calls (request time, status code)
  - Add dlp metrics (max findings, chunks per findings, total chunks)
  - Add org, stdout, stderr and exitcode metrics

## TODO

- [x] Add service account with limited scope to GCP project (only with permission to inspect content and nothing else)