### PR TITLE
Add elixir command line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER RunOps first@runops.io
 ARG VERSION
 ARG NODE_VERSION=16.13.0
 ARG CLOJURE_VERSION=1.10.3.1040
+ARG ELIXIR_VERSION=1.13.0-1
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV ACCEPT_EULA=y
@@ -91,13 +92,16 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /e
     curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     curl -sL https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - && \
     curl -sL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl -fsSLO https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \
+        dpkg -i erlang-solutions_2.0_all.deb
 
 RUN apt-get update -y && \
     apt-get install -y \
         mongodb-org-tools mongodb-org-shell libyaml-cpp0.6 \
         vault=1.5.9 libcap2-bin \
         openjdk-11-jre \
+        elixir=$ELIXIR_VERSION \
         default-mysql-client \
         postgresql-client-13 \
         mssql-tools unixodbc-dev && \

--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -162,6 +162,17 @@
                         :PATH (System/getenv "PATH")
                         :NODE_PATH "/usr/local/lib/node_modules/")))
 
+(defn sh-elixir [task]
+  (let [_ (shell/sh "gosu" "runops" "mix" "local.hex" "--if-missing" "--force")
+        script-file (File/createTempFile "task-" (str (:id task)))
+        _ (spit script-file (:script task))
+        script-path (.getAbsolutePath script-file)
+        output (shell/sh "gosu" "runops" "elixir" script-path
+                         :env {:PATH (System/getenv "PATH")
+                               :HOME (System/getenv "HOME")})]
+    (.delete script-file)
+    output))
+
 (def sh-rails
   (fn [task] (shell/sh "rails" (:script task))))
 
@@ -264,6 +275,7 @@ fi")
    :sql-server        sh-mssql
    :python            sh-python
    :rails             sh-rails
+   :elixir            sh-elixir
    :rails-console     sh-rails-console
    :rails-console-k8s sh-rails-console-k8s
    :rails-console-ecs sh-rails-console-ecs})


### PR DESCRIPTION
Allow executing elixir scripts in the agent. Dependencies should be passed inline. e.g.:

```elixir
# install dependencies when running the script
Mix.install([:jason])
IO.puts(Jason.encode!(%{hello: :world}))
```

## TODO

- [x] Add elixir type to the api