### PR TITLE
Allow upload task output with AWS S3 pre-signed-uri

### DIFF
--- a/resources/agent.proto
+++ b/resources/agent.proto
@@ -47,7 +47,7 @@ message TaskResponse {
   string token = 11;
   bool keep_alive_task = 12;
   string redact = 13;
-  string pre_signed_url = 14;
+  string pre_signed_upload_url = 14;
 }
 
 message LogsRequest {

--- a/resources/agent.proto
+++ b/resources/agent.proto
@@ -47,6 +47,7 @@ message TaskResponse {
   string token = 11;
   bool keep_alive_task = 12;
   string redact = 13;
+  string pre_signed_url = 14;
 }
 
 message LogsRequest {

--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -597,15 +597,15 @@ fi")
                 :redacted true) nil])))
 
 (defn s3-upload [task]
-  (let [task-output (if (= (:shell-exit-code task) 0)
+  (let [task-output (if (= 0 (:shell-exit-code task))
                       (:shell-stdout task)
                       (:shell-stderr task))
-        pre-signed-url (:pre-signed-url task)
+        pre-signed-url (:pre-signed-upload-url task)
         res (try
               (if (clojure.string/blank? pre-signed-url)
                 {:status -1 :chunked? false :request-time 0 :protocol-version {:name "HTTP" :major 1 :minor 1}}
-                (http-client/put (:pre-signed-url task) {:content-type "application/octet-stream"
-                                                         :body task-output}))
+                (http-client/put (:pre-signed-upload-url task) {:content-type "application/octet-stream"
+                                                                :body task-output}))
               (catch Exception e
                 (let [inf (ex-data e)]
                   (log/warn e {:task-id (:id task)} "failed to upload task to S3")

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -11,7 +11,10 @@
             [backoff.time :as backoff]
             [runtime.init :as init]
             [mount.core :as mount]
-            [dlp.gcp :as dlp])
+            [dlp.gcp :as dlp]
+            [clj-http.client :as http-client]
+            [amazonica.aws.s3 :as s3]
+            [amazonica.core :refer [with-credential]])
   (:gen-class))
 
 (def tags (System/getenv "TAGS"))

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -11,10 +11,7 @@
             [backoff.time :as backoff]
             [runtime.init :as init]
             [mount.core :as mount]
-            [dlp.gcp :as dlp]
-            [clj-http.client :as http-client]
-            [amazonica.aws.s3 :as s3]
-            [amazonica.core :refer [with-credential]])
+            [dlp.gcp :as dlp])
   (:gen-class))
 
 (def tags (System/getenv "TAGS"))

--- a/src/agent/grpc_subscriber.clj
+++ b/src/agent/grpc_subscriber.clj
@@ -60,7 +60,7 @@
                     "finished running task async.")
           (catch Exception e
             (queue-info-remove (:id task))
-            (log/error {:task-id (:id task) :queue (queue-length)} e "failed to run task.")
+            (log/error e {:task-id (:id task) :queue (queue-length)} "failed to run task.")
             (sentry-task-logger e task "failed to process message")))))))
 
 (defn when-closed [future-to-watch callback]

--- a/src/io/grpc.cljc
+++ b/src/io/grpc.cljc
@@ -497,13 +497,14 @@
 ;-----------------------------------------------------------------------------
 ; TaskResponse
 ;-----------------------------------------------------------------------------
-(defrecord TaskResponse-record [token config custom-command x-b3-parent-span-id id secret-provider script keep-alive-task secret-path type secret-mapping redact x-b3-trace-id]
+(defrecord TaskResponse-record [token config custom-command x-b3-parent-span-id pre-signed-url id secret-provider script keep-alive-task secret-path type secret-mapping redact x-b3-trace-id]
   pb/Writer
   (serialize [this os]
     (serdes.core/write-String 11  {:optimize true} (:token this) os)
     (serdes.core/write-String 7  {:optimize true} (:config this) os)
     (serdes.core/write-String 10  {:optimize true} (:custom-command this) os)
     (serdes.core/write-String 9  {:optimize true} (:x-b3-parent-span-id this) os)
+    (serdes.core/write-String 14  {:optimize true} (:pre-signed-url this) os)
     (serdes.core/write-Int32 1  {:optimize true} (:id this) os)
     (serdes.core/write-String 4  {:optimize true} (:secret-provider this) os)
     (serdes.core/write-String 3  {:optimize true} (:script this) os)
@@ -521,6 +522,7 @@
 (s/def :io.grpc.TaskResponse/config string?)
 (s/def :io.grpc.TaskResponse/custom-command string?)
 (s/def :io.grpc.TaskResponse/x-b3-parent-span-id string?)
+(s/def :io.grpc.TaskResponse/pre-signed-url string?)
 (s/def :io.grpc.TaskResponse/id int?)
 (s/def :io.grpc.TaskResponse/secret-provider string?)
 (s/def :io.grpc.TaskResponse/script string?)
@@ -530,8 +532,8 @@
 (s/def :io.grpc.TaskResponse/secret-mapping string?)
 (s/def :io.grpc.TaskResponse/redact string?)
 (s/def :io.grpc.TaskResponse/x-b3-trace-id string?)
-(s/def ::TaskResponse-spec (s/keys :opt-un [:io.grpc.TaskResponse/token :io.grpc.TaskResponse/config :io.grpc.TaskResponse/custom-command :io.grpc.TaskResponse/x-b3-parent-span-id :io.grpc.TaskResponse/id :io.grpc.TaskResponse/secret-provider :io.grpc.TaskResponse/script :io.grpc.TaskResponse/keep-alive-task :io.grpc.TaskResponse/secret-path :io.grpc.TaskResponse/type :io.grpc.TaskResponse/secret-mapping :io.grpc.TaskResponse/redact :io.grpc.TaskResponse/x-b3-trace-id ]))
-(def TaskResponse-defaults {:token "" :config "" :custom-command "" :x-b3-parent-span-id "" :id 0 :secret-provider "" :script "" :keep-alive-task false :secret-path "" :type "" :secret-mapping "" :redact "" :x-b3-trace-id "" })
+(s/def ::TaskResponse-spec (s/keys :opt-un [:io.grpc.TaskResponse/token :io.grpc.TaskResponse/config :io.grpc.TaskResponse/custom-command :io.grpc.TaskResponse/x-b3-parent-span-id :io.grpc.TaskResponse/pre-signed-url :io.grpc.TaskResponse/id :io.grpc.TaskResponse/secret-provider :io.grpc.TaskResponse/script :io.grpc.TaskResponse/keep-alive-task :io.grpc.TaskResponse/secret-path :io.grpc.TaskResponse/type :io.grpc.TaskResponse/secret-mapping :io.grpc.TaskResponse/redact :io.grpc.TaskResponse/x-b3-trace-id ]))
+(def TaskResponse-defaults {:token "" :config "" :custom-command "" :x-b3-parent-span-id "" :pre-signed-url "" :id 0 :secret-provider "" :script "" :keep-alive-task false :secret-path "" :type "" :secret-mapping "" :redact "" :x-b3-trace-id "" })
 
 (defn cis->TaskResponse
   "CodedInputStream to TaskResponse"
@@ -543,6 +545,7 @@
                7 [:config (serdes.core/cis->String is)]
                10 [:custom-command (serdes.core/cis->String is)]
                9 [:x-b3-parent-span-id (serdes.core/cis->String is)]
+               14 [:pre-signed-url (serdes.core/cis->String is)]
                1 [:id (serdes.core/cis->Int32 is)]
                4 [:secret-provider (serdes.core/cis->String is)]
                3 [:script (serdes.core/cis->String is)]

--- a/src/io/grpc.cljc
+++ b/src/io/grpc.cljc
@@ -497,16 +497,16 @@
 ;-----------------------------------------------------------------------------
 ; TaskResponse
 ;-----------------------------------------------------------------------------
-(defrecord TaskResponse-record [token config custom-command x-b3-parent-span-id pre-signed-url id secret-provider script keep-alive-task secret-path type secret-mapping redact x-b3-trace-id]
+(defrecord TaskResponse-record [token config custom-command x-b3-parent-span-id id secret-provider pre-signed-upload-url script keep-alive-task secret-path type secret-mapping redact x-b3-trace-id]
   pb/Writer
   (serialize [this os]
     (serdes.core/write-String 11  {:optimize true} (:token this) os)
     (serdes.core/write-String 7  {:optimize true} (:config this) os)
     (serdes.core/write-String 10  {:optimize true} (:custom-command this) os)
     (serdes.core/write-String 9  {:optimize true} (:x-b3-parent-span-id this) os)
-    (serdes.core/write-String 14  {:optimize true} (:pre-signed-url this) os)
     (serdes.core/write-Int32 1  {:optimize true} (:id this) os)
     (serdes.core/write-String 4  {:optimize true} (:secret-provider this) os)
+    (serdes.core/write-String 14  {:optimize true} (:pre-signed-upload-url this) os)
     (serdes.core/write-String 3  {:optimize true} (:script this) os)
     (serdes.core/write-Bool 12  {:optimize true} (:keep-alive-task this) os)
     (serdes.core/write-String 5  {:optimize true} (:secret-path this) os)
@@ -522,9 +522,9 @@
 (s/def :io.grpc.TaskResponse/config string?)
 (s/def :io.grpc.TaskResponse/custom-command string?)
 (s/def :io.grpc.TaskResponse/x-b3-parent-span-id string?)
-(s/def :io.grpc.TaskResponse/pre-signed-url string?)
 (s/def :io.grpc.TaskResponse/id int?)
 (s/def :io.grpc.TaskResponse/secret-provider string?)
+(s/def :io.grpc.TaskResponse/pre-signed-upload-url string?)
 (s/def :io.grpc.TaskResponse/script string?)
 (s/def :io.grpc.TaskResponse/keep-alive-task boolean?)
 (s/def :io.grpc.TaskResponse/secret-path string?)
@@ -532,8 +532,8 @@
 (s/def :io.grpc.TaskResponse/secret-mapping string?)
 (s/def :io.grpc.TaskResponse/redact string?)
 (s/def :io.grpc.TaskResponse/x-b3-trace-id string?)
-(s/def ::TaskResponse-spec (s/keys :opt-un [:io.grpc.TaskResponse/token :io.grpc.TaskResponse/config :io.grpc.TaskResponse/custom-command :io.grpc.TaskResponse/x-b3-parent-span-id :io.grpc.TaskResponse/pre-signed-url :io.grpc.TaskResponse/id :io.grpc.TaskResponse/secret-provider :io.grpc.TaskResponse/script :io.grpc.TaskResponse/keep-alive-task :io.grpc.TaskResponse/secret-path :io.grpc.TaskResponse/type :io.grpc.TaskResponse/secret-mapping :io.grpc.TaskResponse/redact :io.grpc.TaskResponse/x-b3-trace-id ]))
-(def TaskResponse-defaults {:token "" :config "" :custom-command "" :x-b3-parent-span-id "" :pre-signed-url "" :id 0 :secret-provider "" :script "" :keep-alive-task false :secret-path "" :type "" :secret-mapping "" :redact "" :x-b3-trace-id "" })
+(s/def ::TaskResponse-spec (s/keys :opt-un [:io.grpc.TaskResponse/token :io.grpc.TaskResponse/config :io.grpc.TaskResponse/custom-command :io.grpc.TaskResponse/x-b3-parent-span-id :io.grpc.TaskResponse/id :io.grpc.TaskResponse/secret-provider :io.grpc.TaskResponse/pre-signed-upload-url :io.grpc.TaskResponse/script :io.grpc.TaskResponse/keep-alive-task :io.grpc.TaskResponse/secret-path :io.grpc.TaskResponse/type :io.grpc.TaskResponse/secret-mapping :io.grpc.TaskResponse/redact :io.grpc.TaskResponse/x-b3-trace-id ]))
+(def TaskResponse-defaults {:token "" :config "" :custom-command "" :x-b3-parent-span-id "" :id 0 :secret-provider "" :pre-signed-upload-url "" :script "" :keep-alive-task false :secret-path "" :type "" :secret-mapping "" :redact "" :x-b3-trace-id "" })
 
 (defn cis->TaskResponse
   "CodedInputStream to TaskResponse"
@@ -545,9 +545,9 @@
                7 [:config (serdes.core/cis->String is)]
                10 [:custom-command (serdes.core/cis->String is)]
                9 [:x-b3-parent-span-id (serdes.core/cis->String is)]
-               14 [:pre-signed-url (serdes.core/cis->String is)]
                1 [:id (serdes.core/cis->Int32 is)]
                4 [:secret-provider (serdes.core/cis->String is)]
+               14 [:pre-signed-upload-url (serdes.core/cis->String is)]
                3 [:script (serdes.core/cis->String is)]
                12 [:keep-alive-task (serdes.core/cis->Bool is)]
                5 [:secret-path (serdes.core/cis->String is)]

--- a/src/runtime/init.clj
+++ b/src/runtime/init.clj
@@ -66,7 +66,7 @@
           json/read-str
           keywordize-keys)
      (catch Exception e
-       (log/error {:jwk-url jwk-url} e "failed to obtain JWK public keys")
+       (log/error e {:jwk-url jwk-url} "failed to obtain JWK public keys")
        ;; passing the :throwable here strangely doesn't work 
        (sentry-logger {:message (format "failed to obtain JWK public keys, ex-info: %s" e)})
        (System/exit 1)))))


### PR DESCRIPTION
Executing tasks will perform a best-effort to upload task output to S3 via pre-signed URL's.
Added metrics to tracing (request-time, status code, chunked, protocol version)