### PR TITLE
Fix envvar to be passed correctly to a Kubernetes installation

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -23,10 +23,8 @@ spec:
       - envFrom:
         - secretRef:
             name: {{ .Release.Name }}-config
-        {{- if .Values.env_var }}
         - secretRef:
             name: {{ .Release.Name }}-envvar
-        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: Always
         resources:

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -37,7 +37,6 @@ data:
   {{- end }}
 {{- end }}
 ---
-{{- if .Values.env_var }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -47,7 +46,10 @@ metadata:
   labels:
     app: "{{ .Release.Name }}"
 data:
-  {{- range $key, $val := .Values.env_var }}
-  {{ $key }}: {{ printf "%v" $val | b64enc }}
+{{- if .Values.env_var }}
+  {{- range $val := .Values.env_var }}
+  {{ .env }}: {{ .vars | toJson | b64enc }}
   {{- end}}
+{{ else }}
+  NOOP_ENVVAR: {{ "noop" | b64enc }}
 {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -25,10 +25,30 @@ config:
 
 # if you're using env-var as a secret provider, specify the configuration
 # of targets in this key, those values will be available as environment variables
-# when accesses through scripts like (bash, python, elixir, etc)
+# when accesses through scripts like (bash, python, elixir, etc).
+# In case of database types (mysql, postgres, etc), it will be used as parameters 
+# to connect to database instances.
 # https://runops.io/docs/concepts/targets/#secret_provider
 # https://runops.io/docs/concepts/integrations
-env_var: {}
+# env_var:
+#   - env: MYSQL_CONFIG
+#     val:
+#       MYSQL_HOST: 127.0.0.1
+#       MYSQL_USER: root
+#       MYSQL_DB: testdb
+#       MYSQL_PASS: rootpasswd
+#       MYSQL_PORT: 3306
+#   - env: PG_CONFIG
+#     val:
+#       PG_HOST: 127.0.0.1
+#       PG_USER: root
+#       PG_DB: pgdb
+#       PG_PASS: pgpasswd
+#       PG_PORT: 5432
+#   - env: APP_CONFIG
+#     val:
+#       MYAPP_SECRET: supersecret
+#       MYAPP_KEY: appkey
 
 image:
   repository: runops/agent


### PR DESCRIPTION
- Allow multiple env-vars to be specified in helm
- Updated docs

## Example

```sh
helm upgrade --install agent-dev ./charts \
    --set config.token=agent-token \
    --set config.tags=dev \
    --set env_var[0].env=PG_CONFIG \
    --set env_var[0].vars.PG_HOST=127.0.0.1 \
    --set env_var[0].vars.PG_USER=root \
    --set env_var[0].vars.PG_PASS=pg-root-pass \
    --set env_var[0].vars.PG_DB=appdb-dev \
    --set env_var[1].env=MYSQL_CONFIG \
    --set env_var[1].vars.MYSQL_HOST=127.0.0.1 \
    --set env_var[1].vars.MYSQL_USER=root \
    --set env_var[1].vars.MYSQL_PASS=mysql-db-pass \
    --set env_var[1].vars.MYSQL_DB=appdb-homolog \
    --set env_var[2].env=APP_CONFIG \
    --set env_var[2].vars.MYAPP_SECRET=mysuper-secret \
    --set env_var[2].vars.MYAPP_KEY=appkey \
    --namespace runops
```