### PR TITLE
Execute mongo queries via stdin instead of passing through --eval

### DIFF
--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -89,7 +89,7 @@
 
 (def sh-mongo
   (fn [task] (shell/sh "mongo" (:MONGO_CONNECTION_URI (:secrets task))
-                       "--eval" (:script task))))
+                       :in (:script task))))
 
 (def sh-mysql
   (fn [task] (shell/sh "mysql"


### PR DESCRIPTION
Prevents errors when passing argument list too long to the parameter:
> Cannot run program "mongo": error=7, Argument list too long