### PR TITLE
Pass proc-chan properly to shell/sh

### DIFF
--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -64,7 +64,7 @@
                    script-items (clojure.string/split (:script task) #" ")
                    command-items (apply conj ["kubectl" "--kubeconfig" (.getAbsolutePath kube-file)]
                                         script-items)
-                   command-items (conj command-items [:proc-chan (:proc-chan task)])
+                   command-items (apply conj command-items [:proc-chan (:proc-chan task)])
                    sh (apply shell/sh command-items)]
                (.delete kube-file)
                sh)))


### PR DESCRIPTION
Running a task with `k8s` type was returning the error below:


> shell command failed
No value supplied for key: [:proc-chan {:in #object[clojure.core.async.impl.channels.ManyToManyChannel 0x7ca52146 "clojure.core.async.impl.channels.ManyToManyChannel@7ca52146"], :out #object[clojure.core.async.impl.channels.ManyToManyChannel 0x12551e42 "clojure.core.async.impl.channels.ManyToManyChannel@12551e42"]}]