### PR TITLE
Add validation to kill task request only for certain types of task

### DIFF
--- a/src/agent/types.clj
+++ b/src/agent/types.clj
@@ -55,6 +55,7 @@
 (s/defschema KillTaskRequest
   "api -> agent"
   {:id s/Int
+   :type s/Str
    s/Any s/Any})
 
 (s/defschema KillTaskResponse


### PR DESCRIPTION
Don't allow killing tasks for `ecs-exec`, `k8s-exec` and `rails-console-ecs`