### PR TITLE
Add option to send errors to stderr for sqlcmd command

### DIFF
--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -129,7 +129,7 @@
   (let [secrets (:secrets task)
         field-separator (:FIELD_SEPARATOR secrets)
         field-separator? (not (clojure.string/blank? field-separator))]
-    (apply shell/sh (into ["sqlcmd" "-b"
+    (apply shell/sh (into ["sqlcmd" "-b" "-r"
                            "-S" (:MSSQL_CONNECTION_URI secrets)
                            "-U" (:MSSQL_USER secrets)
                            "-P" (:MSSQL_PASS secrets)


### PR DESCRIPTION
Sends messages properly to stderr when a syntax error happens.