### PR TITLE
Add RUNOPS_USER_GROUPS metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ build/
 .idea/
 *.iml
 .calva
+.vscode
 
 # Linter
 .lsp

--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -545,12 +545,14 @@ fi")
   (let [task-id (:id task)
         target (:target task)
         description (:description task)
-        user-email (:user-email task)]
+        user-email (:user-email task)
+        user-groups (:user-groups task)]
     [(assoc task :secrets (conj (:secrets task)
                                 {:RUNOPS_TASK_ID task-id
                                  :RUNOPS_TASK_TARGET target
                                  :RUNOPS_TASK_DESCRIPTION description
-                                 :RUNOPS_TASK_USER_EMAIL user-email})) nil]))
+                                 :RUNOPS_TASK_USER_EMAIL user-email
+                                 :RUNOPS_USER_GROUPS user-groups})) nil]))
 
 (defn parse-hooks [task]
   (try


### PR DESCRIPTION
Allows obtaining the user groups of a task from script types (bash, elixir, node, python, etc)