### PR TITLE
Use mongosh instead of mongo which is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /e
 
 RUN apt-get update -y && \
     apt-get install -y \
-        mongodb-org-tools mongodb-org-shell libyaml-cpp0.6 \
+        mongodb-mongosh mongodb-org-tools mongodb-org-shell libyaml-cpp0.6 \
         vault=1.5.9 libcap2-bin \
         heroku=7.60.2-1 \
         openjdk-11-jre \

--- a/src/agent/agent.clj
+++ b/src/agent/agent.clj
@@ -70,7 +70,7 @@
                sh)))
 
 (def sh-mongo
-  (fn [task] (shell/sh "mongo" "--quiet" (:MONGO_CONNECTION_URI (:secrets task))
+  (fn [task] (shell/sh "mongosh" "--quiet" (:MONGO_CONNECTION_URI (:secrets task))
                        :in (:script task)
                        :proc-chan (:proc-chan task))))
 


### PR DESCRIPTION
- This change maintains [backwards compatibility](https://www.mongodb.com/docs/manual/reference/program/mongo/#std-label-compare-mongosh-mongo)

The `mongo` cli still could be used with `bash` type targets