### PR TITLE
Feat/web server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ build/
 # Linter
 .lsp
 .clj-kondo/.cache
+
+# General files
+secrets.json

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject agent "latest"
+(defproject agent "0.0.0"
   :description "Runops Agent"
   :url "https://github.com/runops/agent"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject agent "0.0.0"
+(defproject agent "latest"
   :description "Runops Agent"
   :url "https://github.com/runops/agent"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
@@ -25,7 +25,8 @@
                  [org.ow2.asm/asm "9.1"]
 
                  ; web server
-                 [yada "1.2.15"]
+                 [aleph "0.5.0"]
+                 [compojure "1.7.0"]
 
                  ; monitoring
                  [io.sentry/sentry-clj "5.7.171"]

--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,9 @@
                  ;; -- Jetty Client Dep --
                  [org.ow2.asm/asm "9.1"]
 
+                 ; web server
+                 [yada "1.2.15"]
+
                  ; monitoring
                  [io.sentry/sentry-clj "5.7.171"]
                  [io.honeycomb/honeycomb-opentelemetry-sdk "0.4.0"]

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -28,12 +28,7 @@
 (defn -main [& _]
   (log/info {:git-revision git-revision :tags tags :os (System/getProperty "os.name")}
             "Starting agent")
-  (let [runtime-config {:org "TestWorkspace"
-                        :hc-dataset "runops"
-                        :hc-api-key "e8f9fb62e7ff1ece4d8020df4cff5954"
-                        :sentry-dsn "https://7bee01d63c85471188c9157e62c79771@o919346.ingest.sentry.io/5863449"
-                        :sentry-env "local"
-                        :connection-config {:backoff-http-poll 15000, :backoff-grpc-connect-subscribe 5000, :grpc-connect-channel-timeout 300000}};(init/fetch-agent-config)
+  (let [runtime-config (init/fetch-agent-config)
         _ (-> (mount/with-args runtime-config) mount/start)
         well-known-jwks (init/fetch-jwks-pubkeys)
         backoff-grpc-connect-subscribe (get-in runtime-config [:connection-config :backoff-grpc-connect-subscribe])

--- a/src/agent/core.clj
+++ b/src/agent/core.clj
@@ -9,6 +9,7 @@
             [logger.timbre-json :as timbre-json]
             [taoensso.timbre.appenders.core :as appenders]
             [agent.control-plane :as cp]
+            [agent.server :as server]
             [backoff.time :as backoff]
             [runtime.init :as init]
             [mount.core :as mount]
@@ -27,7 +28,12 @@
 (defn -main [& _]
   (log/info {:git-revision git-revision :tags tags :os (System/getProperty "os.name")}
             "Starting agent")
-  (let [runtime-config (init/fetch-agent-config)
+  (let [runtime-config {:org "TestWorkspace"
+                        :hc-dataset "runops"
+                        :hc-api-key "e8f9fb62e7ff1ece4d8020df4cff5954"
+                        :sentry-dsn "https://7bee01d63c85471188c9157e62c79771@o919346.ingest.sentry.io/5863449"
+                        :sentry-env "local"
+                        :connection-config {:backoff-http-poll 15000, :backoff-grpc-connect-subscribe 5000, :grpc-connect-channel-timeout 300000}};(init/fetch-agent-config)
         _ (-> (mount/with-args runtime-config) mount/start)
         well-known-jwks (init/fetch-jwks-pubkeys)
         backoff-grpc-connect-subscribe (get-in runtime-config [:connection-config :backoff-grpc-connect-subscribe])
@@ -42,6 +48,7 @@
                       backoff-grpc-connect-subscribe
                       backoff-http-poll
                       (count (:dlp-fields runtime-config))))
+    (server/listen-http)
     (try
       (cp/run-controller {:org (get (mount/args) :org "")
                           :well-known-jwks well-known-jwks

--- a/src/agent/secrets.clj
+++ b/src/agent/secrets.clj
@@ -82,13 +82,13 @@
   "secrets.json")
 
 (defn persist-secret [secret]
-  (log/info "Persisting filesystem secret")
+  (log/info "Persisting filesystem secrets")
   (try
-    (spit default-filesystem-location (clojure.data.json/write-str secret))
+    (spit default-filesystem-location secret)
     [secret nil]
     (catch Exception e
-      (log/error "failed to persis filesystem secret")
-      [nil "failed to persis filesystem secret"])))
+      (log/error (format "Failed to persist filesystem secrets with error: %s" e))
+      [nil "failed to persist filesystem secrets"])))
 
 (defmethod fetch "filesystem" [task]
   (log/info (format "Fetching secrets from filesystem for task id: %s" (:id task)))

--- a/src/agent/secrets.clj
+++ b/src/agent/secrets.clj
@@ -106,7 +106,8 @@
       (do (log/error (format "failed to get filesystem '%s'" (:secret-path task)))
           [nil (format "Failed to read filesystem secret '%s'" (:secret-path task))]))
     (catch Exception e
-      (log/error (format "failed to get filesystem '%s'" (:secret-path task)))
+      (log/error (format "failed to get filesystem '%s' with error %s" (:secret-path task) e))
+      (sentry-task-logger e task "Failed to fetch filesystem secrets")
       [nil (format "Failed to read filesystem secret '%s'" (:secret-path task))])))
 
 

--- a/src/agent/server.clj
+++ b/src/agent/server.clj
@@ -1,20 +1,37 @@
 (ns agent.server
   (:require [yada.yada :refer [listener resource as-resource handler]]
-            [logger.timbre :as log]))
+            [schema.core :as s]
+            [agent.secrets :as secrets]
+            [agent.errors :as err]))
+
+
 
 ;; yada
-(handler
-  {:methods
-   {:get
-    {:produces "text/html"
-     :response "<h1>Hello World!</h1>"}}})
+(def secret-resource
+  (resource {:id      :resources/secrets
+             :methods {:post {:consumes   "application/json"
+                              :produces   "application/json"
+                              :parameters {:body s/Any}
+                              :response
+                                          (fn [ctx]
+                                            (let [result (err/err->> (:body ctx)
+                                                                     secrets/persist-secret)]
+                                              (if (first result)
+                                                (first result)
+                                                (:body ctx))))}
+
+                       :get  {:produces "application/json"
+                              :response (fn [ctx]
+                                          (let [result (err/err->> {}
+                                                                   secrets/get-filesystem-secret)]
+                                            (if (first result)
+                                              (:secrets (first result))
+                                              (second result))))}}}))
 
 (defn listen-http []
   (listener
     ["/"
      [
-      ["hello" (as-resource "Hello World!")]
-      ["test" (resource {:produces "text/plain"
-                         :response "This is a test!"})]
+      ["secrets" secret-resource]
       [true (as-resource nil)]]]
     {:port 3000}))

--- a/src/agent/server.clj
+++ b/src/agent/server.clj
@@ -1,0 +1,20 @@
+(ns agent.server
+  (:require [yada.yada :refer [listener resource as-resource handler]]
+            [logger.timbre :as log]))
+
+;; yada
+(handler
+  {:methods
+   {:get
+    {:produces "text/html"
+     :response "<h1>Hello World!</h1>"}}})
+
+(defn listen-http []
+  (listener
+    ["/"
+     [
+      ["hello" (as-resource "Hello World!")]
+      ["test" (resource {:produces "text/plain"
+                         :response "This is a test!"})]
+      [true (as-resource nil)]]]
+    {:port 3000}))

--- a/src/agent/types.clj
+++ b/src/agent/types.clj
@@ -13,7 +13,7 @@
    :script s/Str
    (s/optional-key :config) (s/maybe s/Str)
    (s/optional-key :redact) (s/maybe (s/enum "all" "none"))
-   (s/optional-key :secret-provider) (s/maybe (s/enum "runops" "aws" "env-var"
+   (s/optional-key :secret-provider) (s/maybe (s/enum "runops" "aws" "env-var" "filesystem"
                                                       "hashicorp/db" "hashicorp/kv"))
    (s/optional-key :secret-path) (s/maybe s/Str)
    (s/optional-key :secret-mapping) (s/maybe s/Str)


### PR DESCRIPTION
- Added webserver (aleph webserver)
- Added 2 endpoints, POST /v1/secrets and GET /v1/secrets
- Added "filesystem" secrets support

Note: aleph webserver was choosen because the traditional pedestal/ring packages are failing to boot due to jetty version conflicts (protojure). Protojure uses 11.x while pedestal/ring uses 9x.